### PR TITLE
Allow to configure metrics listener, off by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -42,6 +42,15 @@ var mysqlInfo = &MysqlInfo{
 	MaxOpenConns: 50,
 }
 
+type MetricsInfo struct {
+	Host string `ini:"host"`
+	Port string `ini:"port"`
+}
+
+var metricsInfo = &MetricsInfo{
+	Port: "8080",
+}
+
 func ParseConfig(path string) error {
 	cfg, err := ini.Load(path)
 	if err != nil {
@@ -69,6 +78,10 @@ func ParseConfig(path string) error {
 		return err
 	}
 
+	if err = cfg.Section("metrics").MapTo(metricsInfo); err != nil {
+		return err
+	}
+
 	if mysqlInfo.Host == "" {
 		return errors.New("missing mysql host")
 	}
@@ -89,4 +102,8 @@ func GetMysqlInfo() *MysqlInfo {
 
 func GetRedisInfo() *RedisInfo {
 	return redisInfo
+}
+
+func GetMetricsInfo() *MetricsInfo {
+	return metricsInfo
 }

--- a/icingadb.ini
+++ b/icingadb.ini
@@ -8,3 +8,7 @@ password="icinga0815!"
 
 [logging]
 level="info"
+
+[metrics]
+#host="127.0.0.1"
+#port=8080

--- a/main.go
+++ b/main.go
@@ -76,6 +76,7 @@ func main() {
 
 	redisInfo := config.GetRedisInfo()
 	mysqlInfo := config.GetMysqlInfo()
+	metricsInfo := config.GetMetricsInfo()
 
 	redisConn := connection.NewRDBWrapper(redisInfo.Host+":"+redisInfo.Port, redisInfo.PoolSize)
 
@@ -114,7 +115,9 @@ func main() {
 
 	go haInstance.StartEventListener()
 
-	go prometheus.HandleHttp("0.0.0.0:8080", super.ChErr)
+	if metricsInfo.Host != "" {
+		go prometheus.HandleHttp(metricsInfo.Host+":"+metricsInfo.Port, super.ChErr)
+	}
 
 	for {
 		select {


### PR DESCRIPTION
Depends on #1

# Before 

```
$ ./icingadb
INFO[0000] Connecting to Redis
INFO[0000] Connecting to MySQL
INFO[0000] Redis connection established
ERRO[0000] Could not connect to SQL. Trying again        context=sql error="Error 1045: Access denied for user 'module-dev'@'localhost' (using password: YES)"
INFO[0000] Starting heartbeat listener
INFO[0000] Serving metrics at http://0.0.0.0:8080/metrics
FATA[0000] listen tcp 0.0.0.0:8080: bind: address already in use
```

# After

## Default

```
$ ./icingadb
INFO[0000] Connecting to Redis
INFO[0000] Connecting to MySQL
INFO[0000] Redis connection established
ERRO[0000] Could not connect to SQL. Trying again        context=sql error="Error 1045: Access denied for user 'module-dev'@'localhost' (using password: YES)"
INFO[0000] Starting heartbeat listener
```

## With Configuration

```
[metrics]
host="127.0.0.1"
port=8081
```

```
$ ./icingadb
INFO[0000] Connecting to Redis
INFO[0000] Connecting to MySQL
INFO[0000] Redis connection established
ERRO[0000] Could not connect to SQL. Trying again        context=sql error="Error 1045: Access denied for user 'module-dev'@'localhost' (using password: YES)"
INFO[0000] Starting heartbeat listener
INFO[0000] Serving metrics at http://127.0.0.1:8081/metrics
```