### PR TITLE
State: Read hard_state/last_hard_state only once

### DIFF
--- a/configobject/objecttypes/host/hoststate/hoststate.go
+++ b/configobject/objecttypes/host/hoststate/hoststate.go
@@ -48,7 +48,6 @@ type HostState struct {
 	EnvId                    string  `json:"environment_id"`
 	StateType                float32 `json:"state_type"`
 	SoftState                float32 `json:"state"`
-	HardState                float32 `json:"last_hard_state"`
 	PreviousHardState        float32 `json:"previous_hard_state"`
 	Attempt                  float32 `json:"check_attempt"`
 	Severity                 float32 `json:"severity"`
@@ -95,7 +94,7 @@ func (h *HostState) UpdateValues() []interface{} {
 		utils.EncodeChecksum(h.EnvId),
 		utils.IcingaStateTypeToString(h.StateType),
 		h.SoftState,
-		h.HardState,
+		h.LastHardState,
 		h.PreviousHardState,
 		h.Attempt,
 		h.Severity,

--- a/configobject/objecttypes/service/servicestate/servicestate.go
+++ b/configobject/objecttypes/service/servicestate/servicestate.go
@@ -48,7 +48,6 @@ type ServiceState struct {
 	EnvId                    string  `json:"environment_id"`
 	StateType                float32 `json:"state_type"`
 	SoftState                float32 `json:"state"`
-	HardState                float32 `json:"last_hard_state"`
 	PreviousHardState        float32 `json:"previous_hard_state"`
 	Attempt                  float32 `json:"check_attempt"`
 	Severity                 float32 `json:"severity"`
@@ -95,7 +94,7 @@ func (s *ServiceState) UpdateValues() []interface{} {
 		utils.EncodeChecksum(s.EnvId),
 		utils.IcingaStateTypeToString(s.StateType),
 		s.SoftState,
-		s.HardState,
+		s.LastHardState,
 		s.PreviousHardState,
 		s.Attempt,
 		s.Severity,


### PR DESCRIPTION
This is needed, because 2 attributes with the same JSON tag result in 2 empty attributes on JSON unmarshal.