### PR TITLE
MySQL: Make sure to chunk rows correctly

### DIFF
--- a/connection/mysql_utils.go
+++ b/connection/mysql_utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"io/ioutil"
 	oldlog "log"
+	"math"
 	"reflect"
 	"sort"
 	"strconv"
@@ -432,3 +433,20 @@ type Row interface {
 }
 
 type RowFactory func() Row
+
+func ChunkRows(rows []Row, size int) [][]Row {
+	chunksLen := int(math.Ceil(float64(len(rows)) / float64(size)))
+	chunks := make([][]Row, chunksLen)
+
+	for i := 0; i < chunksLen; i++ {
+		start := i * size;
+		end := start + size
+		if end > len(rows) {
+			end = len(rows)
+		}
+
+		chunks[i] = rows[start:end]
+	}
+
+	return chunks
+}

--- a/connection/mysql_utils_test.go
+++ b/connection/mysql_utils_test.go
@@ -9,6 +9,29 @@ import (
 	"testing"
 )
 
+type TestRow struct {
+	Name string
+}
+
+func (*TestRow) InsertValues() []interface{} {
+	return nil
+}
+
+func (*TestRow) UpdateValues() []interface{} {
+	return nil
+}
+
+func (*TestRow) GetId() string {
+	return ""
+}
+
+func (*TestRow) SetId(id string) {
+}
+
+func (*TestRow) GetFinalRows() ([]Row, error) {
+	return nil, nil
+}
+
 func TestMakePlaceholderList(t *testing.T) {
 	assert.Equal(t, "(?)", MakePlaceholderList(1))
 	assert.Equal(t, "(?,?,?,?,?)", MakePlaceholderList(5))
@@ -103,4 +126,74 @@ func TestMysqlConnectionError_Error(t *testing.T) {
 
 func TestFormatLogQuery(t *testing.T) {
 	assert.Equal(t, "This is my string", formatLogQuery("\tThis is\nmy string\n"))
+}
+
+func TestChunkRows(t *testing.T) {
+	rows := []Row{
+		&TestRow{"herp"},
+		&TestRow{"derp"},
+		&TestRow{"merp"},
+		&TestRow{"lerp"},
+		&TestRow{"perp"},
+	}
+
+	want := [][]Row{
+		{
+			rows[0],
+			rows[1],
+			rows[2],
+			rows[3],
+			rows[4],
+		},
+	}
+	chunks := ChunkRows(rows, 5)
+	assert.Equal(t, want, chunks)
+
+	want = [][]Row{
+		{
+			rows[0],
+			rows[1],
+			rows[2],
+			rows[3],
+			rows[4],
+		},
+	}
+	chunks = ChunkRows(rows, 10)
+	assert.Equal(t, want, chunks)
+
+	want = [][]Row{
+		{
+			rows[0],
+		},
+		{
+			rows[1],
+		},
+		{
+			rows[2],
+		},
+		{
+			rows[3],
+		},
+		{
+			rows[4],
+		},
+	}
+	chunks = ChunkRows(rows, 1)
+	assert.Equal(t, want, chunks)
+
+	want = [][]Row{
+		{
+			rows[0],
+			rows[1],
+		},
+		{
+			rows[2],
+			rows[3],
+		},
+		{
+			rows[4],
+		},
+	}
+	chunks = ChunkRows(rows, 2)
+	assert.Equal(t, want, chunks)
 }


### PR DESCRIPTION
This fixes a "too many placeholders" exception caused by large nested custom vars.
Custom vars get flattened by calling `getFinalRows()` on custom var rows.
https://github.com/Icinga/icingadb/blob/49891dfa1b0560dcd038241454f27f13c3a0e8d4/connection/mysql.go#L695

This extends the chunk size of 500 rows, provided by our Redis implementation, by an unlimited amount.

Test config:

```
numHosts = 500
for (hid in range(numHosts)) {
        object Host "TestHost - " + hid use (hid) {
                check_command = "dummy"
                vars.perp = {}
                var numPerpVars = 500
                for (i in range(numPerpVars)) {
                        vars.perp["var" + i] = i + "_" + hid
                }
        }
}
```

This PR might also be the solution for #147, but that needs testing.
