### PR TITLE
Add missing indices to *_customvar tables

### DIFF
--- a/etc/schema/mysql/mysql.schema.sql
+++ b/etc/schema/mysql/mysql.schema.sql
@@ -112,7 +112,10 @@ CREATE TABLE hostgroup_customvar (
   hostgroup_id binary(20) NOT NULL COMMENT 'hostgroup.id',
   customvar_id binary(20) NOT NULL COMMENT 'customvar.id',
 
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+
+  INDEX idx_hostgroup_customvar_hostgroup_id (hostgroup_id, customvar_id),
+  INDEX idx_hostgroup_customvar_customvar_id (customvar_id, hostgroup_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE host_state (
@@ -259,7 +262,10 @@ CREATE TABLE servicegroup_customvar (
   servicegroup_id binary(20) NOT NULL COMMENT 'servicegroup.id',
   customvar_id binary(20) NOT NULL COMMENT 'customvar.id',
 
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+
+  INDEX idx_servicegroup_customvar_servicegroup_id (servicegroup_id, customvar_id),
+  INDEX idx_servicegroup_customvar_customvar_id (customvar_id, servicegroup_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE service_state (
@@ -408,7 +414,11 @@ CREATE TABLE checkcommand_customvar (
 
   command_id binary(20) NOT NULL COMMENT 'command.id',
   customvar_id binary(20) NOT NULL COMMENT 'customvar.id',
-  PRIMARY KEY (id)
+
+  PRIMARY KEY (id),
+
+  INDEX idx_checkcommand_customvar_command_id (command_id, customvar_id),
+  INDEX idx_checkcommand_customvar_customvar_id (customvar_id, command_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 
@@ -467,7 +477,10 @@ CREATE TABLE eventcommand_customvar (
   command_id binary(20) NOT NULL COMMENT 'command.id',
   customvar_id binary(20) NOT NULL COMMENT 'customvar.id',
 
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+
+  INDEX idx_eventcommand_customvar_command_id (command_id, customvar_id),
+  INDEX idx_eventcommand_customvar_customvar_id (customvar_id, command_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE notificationcommand (
@@ -525,7 +538,10 @@ CREATE TABLE notificationcommand_customvar (
   command_id binary(20) NOT NULL COMMENT 'command.id',
   customvar_id binary(20) NOT NULL COMMENT 'customvar.id',
 
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+
+  INDEX idx_notificationcommand_customvar_command_id (command_id, customvar_id),
+  INDEX idx_notificationcommand_customvar_customvar_id (customvar_id, command_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE comment (
@@ -663,7 +679,10 @@ CREATE TABLE notification_customvar (
   notification_id binary(20) NOT NULL COMMENT 'notification.id',
   customvar_id binary(20) NOT NULL COMMENT 'customvar.id',
 
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+
+  INDEX idx_notification_customvar_notification_id (notification_id, customvar_id),
+  INDEX idx_notification_customvar_customvar_id (customvar_id, notification_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE icon_image (
@@ -745,7 +764,10 @@ CREATE TABLE timeperiod_customvar (
   timeperiod_id binary(20) NOT NULL COMMENT 'timeperiod.id',
   customvar_id binary(20) NOT NULL COMMENT 'customvar.id',
 
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+
+  INDEX idx_timeperiod_customvar_timeperiod_id (timeperiod_id, customvar_id),
+  INDEX idx_timeperiod_customvar_customvar_id (customvar_id, timeperiod_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE customvar (
@@ -833,7 +855,10 @@ CREATE TABLE user_customvar (
   user_id binary(20) NOT NULL COMMENT 'user.id',
   customvar_id binary(20) NOT NULL COMMENT 'customvar.id',
 
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+
+  INDEX idx_user_customvar_user_id (user_id, customvar_id),
+  INDEX idx_user_customvar_customvar_id (customvar_id, user_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE usergroup_customvar (
@@ -842,7 +867,10 @@ CREATE TABLE usergroup_customvar (
   usergroup_id binary(20) NOT NULL COMMENT 'usergroup.id',
   customvar_id binary(20) NOT NULL COMMENT 'customvar.id',
 
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+
+  INDEX idx_usergroup_customvar_usergroup_id (usergroup_id, customvar_id),
+  INDEX idx_usergroup_customvar_customvar_id (customvar_id, usergroup_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE zone (


### PR DESCRIPTION
Adds the same indices just like they're already part of `host_customvar` and `service_customvar` to all other `*_customvar` tables