### PR TITLE
HA: Prevent multiple instances from taking over at the same time

### DIFF
--- a/configobject/configsync/configsync.go
+++ b/configobject/configsync/configsync.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"github.com/Icinga/icingadb/configobject"
 	"github.com/Icinga/icingadb/connection"
-	"github.com/Icinga/icingadb/ha"
 	"github.com/Icinga/icingadb/jsondecoder"
 	"github.com/Icinga/icingadb/supervisor"
 	"github.com/Icinga/icingadb/utils"
@@ -60,14 +59,14 @@ func Operator(super *supervisor.Supervisor, chHA chan int, objectInformation *co
 	for msg := range chHA {
 		switch msg {
 		// Icinga 2 probably restarted or died, stop operations and tell all workers to shut down.
-		case ha.Notify_StopSync:
+		case Notify_StopSync:
 			if done != nil {
 				log.Debugf("%s: Lost responsibility", objectInformation.ObjectType)
 				close(done)
 				done = nil
 			}
 		// Starts up the whole sync process.
-		case ha.Notify_StartSync:
+		case Notify_StartSync:
 			if done != nil {
 				continue
 			}

--- a/configobject/configsync/configsync_test.go
+++ b/configobject/configsync/configsync_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/Icinga/icingadb/configobject"
 	"github.com/Icinga/icingadb/configobject/objecttypes/host"
 	"github.com/Icinga/icingadb/connection"
-	"github.com/Icinga/icingadb/ha"
 	"github.com/Icinga/icingadb/jsondecoder"
 	"github.com/Icinga/icingadb/supervisor"
 	"github.com/Icinga/icingadb/utils"
@@ -66,7 +65,7 @@ func TestOperator_InsertHost(t *testing.T) {
 	testbackends.RedisTestClient.HSet("icinga:checksum:host", "a9ef44eb69fda8fbc32bee33322b6518057f559f", "{\"checksum\":\"b6e87de3d4f31b3d4d35466171f4088693b46071\"}")
 
 	for _, ch := range chs {
-		ch <- ha.Notify_StartSync
+		ch <- Notify_StartSync
 	}
 
 	assert.Eventually(t, func() bool {
@@ -142,7 +141,7 @@ func TestOperator_DeleteHost(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, ch := range chs {
-		ch <- ha.Notify_StartSync
+		ch <- Notify_StartSync
 	}
 
 	assert.Eventually(t, func() bool {
@@ -214,7 +213,7 @@ func TestOperator_UpdateHost(t *testing.T) {
 	require.NoError(t, err)
 
 	for _, ch := range chs {
-		ch <- ha.Notify_StartSync
+		ch <- Notify_StartSync
 	}
 
 	assert.Eventually(t, func() bool {

--- a/configobject/configsync/ha.go
+++ b/configobject/configsync/ha.go
@@ -1,0 +1,117 @@
+package configsync
+
+import (
+	"github.com/Icinga/icingadb/ha"
+	"github.com/Icinga/icingadb/supervisor"
+	"github.com/go-redis/redis/v7"
+	log "github.com/sirupsen/logrus"
+	"sync"
+	"time"
+)
+
+const (
+	Notify_StartSync = iota
+	Notify_StopSync
+)
+
+type ConfigSyncHA struct {
+	super                      *supervisor.Supervisor
+	done                       chan struct{}
+	chHA                       <-chan ha.State
+	notificationListeners      map[string][]chan int
+	notificationListenersMutex sync.Mutex
+	lastEventId                string
+	haIsActive                 bool
+}
+
+func NewConfigSyncHA(super *supervisor.Supervisor, chHA <-chan ha.State) *ConfigSyncHA {
+	return &ConfigSyncHA{
+		super:                 super,
+		done:                  make(chan struct{}),
+		chHA:                  chHA,
+		notificationListeners: map[string][]chan int{},
+		lastEventId:           "0-0",
+	}
+}
+
+func (h *ConfigSyncHA) Start() {
+	go h.run()
+}
+
+func (h *ConfigSyncHA) run() {
+	every1s := time.NewTicker(time.Second)
+
+loop:
+	for {
+		select {
+		case <-h.done:
+			log.Info("received done signal, shutting down")
+			break loop
+		case <-every1s.C:
+			h.runEventListener()
+		}
+	}
+}
+
+func (h *ConfigSyncHA) Stop() {
+	close(h.done)
+}
+
+func (h *ConfigSyncHA) runEventListener() {
+	select {
+	case newState := <-h.chHA:
+		h.haIsActive = newState == ha.StateActive
+		if !h.haIsActive {
+			h.lastEventId = "0-0"
+			h.notifyNotificationListener("*", Notify_StopSync)
+		}
+	default: // don't block if there is no change
+	}
+
+	if !h.haIsActive {
+		return
+	}
+
+	result := h.super.Rdbw.XRead(&redis.XReadArgs{Block: -1, Streams: []string{"icinga:dump", h.lastEventId}})
+	streams, err := result.Result()
+	if err != nil {
+		if err.Error() != "redis: nil" {
+			h.super.ChErr <- err
+		}
+		return
+	}
+
+	events := streams[0].Messages
+	if len(events) == 0 {
+		return
+	}
+
+	for _, event := range events {
+		h.lastEventId = event.ID
+		values := event.Values
+
+		if values["state"] == "done" {
+			h.notifyNotificationListener(values["type"].(string), Notify_StartSync)
+		} else {
+			h.notifyNotificationListener(values["type"].(string), Notify_StopSync)
+		}
+	}
+}
+
+func (h *ConfigSyncHA) RegisterNotificationListener(listenerType string) chan int {
+	ch := make(chan int, 10)
+	h.notificationListenersMutex.Lock()
+	h.notificationListeners[listenerType] = append(h.notificationListeners[listenerType], ch)
+	h.notificationListenersMutex.Unlock()
+	return ch
+}
+
+func (h *ConfigSyncHA) notifyNotificationListener(listenerType string, msg int) {
+	for t, chs := range h.notificationListeners {
+		if t == listenerType || listenerType == "*" {
+			for _, c := range chs {
+				c <- msg
+			}
+		}
+	}
+}

--- a/configobject/configsync/ha_test.go
+++ b/configobject/configsync/ha_test.go
@@ -1,0 +1,104 @@
+package configsync
+
+import (
+	"github.com/Icinga/icingadb/config/testbackends"
+	"github.com/Icinga/icingadb/connection"
+	"github.com/Icinga/icingadb/ha"
+	"github.com/Icinga/icingadb/supervisor"
+	"github.com/go-redis/redis/v7"
+	"github.com/stretchr/testify/assert"
+	"sync"
+	"testing"
+)
+
+func GetSuper() *supervisor.Supervisor {
+	redisConn := connection.NewRDBWrapper(testbackends.RedisTestAddr, "", 64)
+
+	return &supervisor.Supervisor{
+		ChErr: make(chan error),
+		Rdbw:  redisConn,
+	}
+}
+
+func TestHA_NotificationListeners(t *testing.T) {
+	super := GetSuper()
+	chHA := make(chan ha.State)
+	haInst := NewConfigSyncHA(super, chHA)
+
+	chHost := haInst.RegisterNotificationListener("host")
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		assert.Equal(t, Notify_StartSync, <-chHost)
+		wg.Done()
+	}()
+
+	haInst.notifyNotificationListener("host", Notify_StartSync)
+	wg.Wait()
+
+	chService := haInst.RegisterNotificationListener("service")
+	wg.Add(1)
+
+	go func() {
+		assert.Equal(t, Notify_StartSync, <-chService)
+		wg.Done()
+	}()
+
+	haInst.notifyNotificationListener("service", Notify_StartSync)
+	wg.Wait()
+
+	wg.Add(1)
+
+	go func() {
+		assert.Equal(t, Notify_StartSync, <-chService)
+		assert.Equal(t, Notify_StartSync, <-chHost)
+		wg.Done()
+	}()
+
+	haInst.notifyNotificationListener("*", Notify_StartSync)
+	wg.Wait()
+}
+
+func TestHA_EventListener(t *testing.T) {
+	super := GetSuper()
+	chHA := make(chan ha.State)
+	haInst := NewConfigSyncHA(super, chHA)
+
+	haInst.Start()
+	defer haInst.Stop()
+
+	chHA <- ha.StateActive
+
+	testbackends.RedisTestClient.Del("icinga:dump")
+
+	chHost := haInst.RegisterNotificationListener("host")
+	chService := haInst.RegisterNotificationListener("service")
+
+	wg := sync.WaitGroup{}
+	wg.Add(2)
+
+	go func() {
+		assert.Equal(t, Notify_StartSync, <-chHost)
+		assert.Equal(t, Notify_StopSync, <-chHost)
+		assert.Equal(t, Notify_StartSync, <-chHost)
+		assert.Equal(t, Notify_StopSync, <-chHost)
+		wg.Done()
+	}()
+
+	go func() {
+		assert.Equal(t, Notify_StartSync, <-chService)
+		assert.Equal(t, Notify_StopSync, <-chService)
+		assert.Equal(t, Notify_StartSync, <-chService)
+		wg.Done()
+	}()
+
+	testbackends.RedisTestClient.XAdd(&redis.XAddArgs{Stream: "icinga:dump", Values: map[string]interface{}{"type": "host", "state": "done"}})
+	testbackends.RedisTestClient.XAdd(&redis.XAddArgs{Stream: "icinga:dump", Values: map[string]interface{}{"type": "host", "state": "wip"}})
+	testbackends.RedisTestClient.XAdd(&redis.XAddArgs{Stream: "icinga:dump", Values: map[string]interface{}{"type": "*", "state": "done"}})
+	testbackends.RedisTestClient.XAdd(&redis.XAddArgs{Stream: "icinga:dump", Values: map[string]interface{}{"type": "*", "state": "wip"}})
+	testbackends.RedisTestClient.XAdd(&redis.XAddArgs{Stream: "icinga:dump", Values: map[string]interface{}{"type": "service", "state": "done"}})
+
+	wg.Wait()
+}

--- a/ha/ha.go
+++ b/ha/ha.go
@@ -25,8 +25,15 @@ type HA struct {
 	uid                       uuid.UUID
 	super                     *supervisor.Supervisor
 	logger                    *log.Entry
-	heartbeatTimer            *time.Timer
 }
+
+const (
+	// We consider heartbeats valid for 10 seconds
+	heartbeatValidMillisecs = 10 * 1000
+
+	// We consider the heartbeat of another instance to be expired 5 seconds after its validity ended
+	heartbeatTimeoutMillisecs = heartbeatValidMillisecs + 5*1000
+)
 
 func NewHA(super *supervisor.Supervisor) (*HA, error) {
 	var err error
@@ -42,17 +49,19 @@ func NewHA(super *supervisor.Supervisor) (*HA, error) {
 }
 
 var mysqlObservers = struct {
-	updateIcingadbInstanceById                           prometheus.Observer
-	updateIcingadbInstanceByEnvironmentId                prometheus.Observer
-	insertIntoIcingadbInstance                           prometheus.Observer
-	insertIntoEnvironment                                prometheus.Observer
-	selectIdHeartbeatFromIcingadbInstanceByEnvironmentId prometheus.Observer
+	updateIcingadbInstanceById                                      prometheus.Observer
+	updateIcingadbInstanceByEnvironmentId                           prometheus.Observer
+	insertIntoIcingadbInstance                                      prometheus.Observer
+	insertIntoEnvironment                                           prometheus.Observer
+	selectIdHeartbeatResponsibleFromIcingadbInstanceByEnvironmentId prometheus.Observer
+	selectHeartbeatResponsibleFromIcingadbInstanceById              prometheus.Observer
 }{
 	connection.DbIoSeconds.WithLabelValues("mysql", "update icingadb_instance by id"),
 	connection.DbIoSeconds.WithLabelValues("mysql", "update icingadb_instance by environment_id"),
 	connection.DbIoSeconds.WithLabelValues("mysql", "insert into icingadb_instance"),
 	connection.DbIoSeconds.WithLabelValues("mysql", "insert into environment"),
-	connection.DbIoSeconds.WithLabelValues("mysql", "select id, heartbeat from icingadb_instance where environment_id = ourEnvID"),
+	connection.DbIoSeconds.WithLabelValues("mysql", "select id, heartbeat, responsible from icingadb_instance where environment_id = ourEnvID"),
+	connection.DbIoSeconds.WithLabelValues("mysql", "select heartbeat, responsible from icingadb_instance by id"),
 }
 
 func (h *HA) setState(state State) {
@@ -82,103 +91,87 @@ func (h *HA) setState(state State) {
 	}
 }
 
-func (h *HA) updateOwnInstance(env *Environment) error {
-	_, err := h.super.Dbw.SqlExec(
-		mysqlObservers.insertIntoIcingadbInstance,
-		"REPLACE INTO icingadb_instance(id, environment_id, endpoint_id, heartbeat, responsible,"+
+func (h *HA) upsertInstance(tx connection.DbTransaction, env *Environment, isActive bool) error {
+	if isActive {
+		// If we are active or become active, ensure that no other instance has the active flag set.
+		_, err := h.super.Dbw.SqlExecTx(tx, mysqlObservers.updateIcingadbInstanceByEnvironmentId,
+			"UPDATE icingadb_instance SET responsible = ? WHERE environment_id = ? AND responsible = ?",
+			utils.Bool[false], h.super.EnvId, utils.Bool[true])
+		if err != nil {
+			return err
+		}
+	}
+
+	_, err := h.super.Dbw.SqlExecTx(
+		tx, mysqlObservers.insertIntoIcingadbInstance,
+		"REPLACE INTO icingadb_instance(id, environment_id, endpoint_id, responsible, heartbeat,"+
 			" icinga2_version, icinga2_start_time, icinga2_notifications_enabled,"+
 			" icinga2_active_service_checks_enabled, icinga2_active_host_checks_enabled,"+
 			" icinga2_event_handlers_enabled, icinga2_flap_detection_enabled,"+
-			" icinga2_performance_data_enabled) VALUES (?, ?, ?, ?, 'y', ?, ?, ?, ?, ?, ?, ?, ?)",
-		h.uid[:],
-		h.super.EnvId,
-		env.Icinga2.EndpointId,
-		h.lastHeartbeat,
-		env.Icinga2.Version,
-		int64(env.Icinga2.ProgramStart*1000),
-		utils.Bool[env.Icinga2.NotificationsEnabled],
-		utils.Bool[env.Icinga2.ActiveServiceChecksEnabled],
-		utils.Bool[env.Icinga2.ActiveHostChecksEnabled],
-		utils.Bool[env.Icinga2.EventHandlersEnabled],
-		utils.Bool[env.Icinga2.FlapDetectionEnabled],
-		utils.Bool[env.Icinga2.PerformanceDataEnabled],
+			" icinga2_performance_data_enabled) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+		h.uid[:],                                           // id
+		h.super.EnvId,                                      // environment_id
+		env.Icinga2.EndpointId,                             // endpoint_id
+		utils.Bool[isActive],                               // responsible
+		h.lastHeartbeat,                                    // heartbeat
+		env.Icinga2.Version,                                // icinga2_version
+		int64(env.Icinga2.ProgramStart*1000),               // icinga2_start_time
+		utils.Bool[env.Icinga2.NotificationsEnabled],       // icinga2_notifications_enabled
+		utils.Bool[env.Icinga2.ActiveServiceChecksEnabled], // icinga2_active_service_checks_enabled
+		utils.Bool[env.Icinga2.ActiveHostChecksEnabled],    // icinga2_active_host_checks_enabled
+		utils.Bool[env.Icinga2.EventHandlersEnabled],       // icinga2_event_handlers_enabled
+		utils.Bool[env.Icinga2.FlapDetectionEnabled],       // icinga2_flap_detection_enabled
+		utils.Bool[env.Icinga2.PerformanceDataEnabled],     // icinga2_performance_data_enabled
 	)
 	return err
 }
 
-func (h *HA) takeOverInstance(env *Environment) error {
-	_, err := h.super.Dbw.SqlExec(
-		mysqlObservers.updateIcingadbInstanceByEnvironmentId,
-		"UPDATE icingadb_instance SET id = ?, endpoint_id = ?, heartbeat = ?,"+
-			" icinga2_version = ?, icinga2_start_time = ?, icinga2_notifications_enabled = ?,"+
-			" icinga2_active_service_checks_enabled = ?, icinga2_active_host_checks_enabled = ?,"+
-			" icinga2_event_handlers_enabled = ?, icinga2_flap_detection_enabled = ?,"+
-			" icinga2_performance_data_enabled = ? WHERE environment_id = ?",
-		h.uid[:],
-		env.Icinga2.EndpointId,
-		h.lastHeartbeat,
-		env.Icinga2.Version,
-		int64(env.Icinga2.ProgramStart*1000),
-		utils.Bool[env.Icinga2.NotificationsEnabled],
-		utils.Bool[env.Icinga2.ActiveServiceChecksEnabled],
-		utils.Bool[env.Icinga2.ActiveHostChecksEnabled],
-		utils.Bool[env.Icinga2.EventHandlersEnabled],
-		utils.Bool[env.Icinga2.FlapDetectionEnabled],
-		utils.Bool[env.Icinga2.PerformanceDataEnabled],
-		h.super.EnvId,
+func (h *HA) getActiveInstance(tx connection.DbTransaction) (bool, uuid.UUID, error) {
+	rows, err := h.super.Dbw.SqlFetchAllTx(
+		tx, mysqlObservers.selectIdHeartbeatResponsibleFromIcingadbInstanceByEnvironmentId,
+		"SELECT id, heartbeat FROM icingadb_instance"+
+			" WHERE environment_id = ? AND responsible = ? AND heartbeat > ?",
+		h.super.EnvId, utils.Bool[true], utils.TimeToMillisecs(time.Now())-heartbeatTimeoutMillisecs,
 	)
-	return err
-}
-
-func (h *HA) insertInstance(env *Environment) error {
-	_, err := h.super.Dbw.SqlExec(
-		mysqlObservers.insertIntoIcingadbInstance,
-		"INSERT INTO icingadb_instance(id, environment_id, endpoint_id, heartbeat, responsible,"+
-			" icinga2_version, icinga2_start_time, icinga2_notifications_enabled,"+
-			" icinga2_active_service_checks_enabled, icinga2_active_host_checks_enabled,"+
-			" icinga2_event_handlers_enabled, icinga2_flap_detection_enabled,"+
-			" icinga2_performance_data_enabled) VALUES (?, ?, ?, ?, 'y', ?, ?, ?, ?, ?, ?, ?, ?)",
-		h.uid[:],
-		h.super.EnvId,
-		env.Icinga2.EndpointId,
-		h.lastHeartbeat,
-		env.Icinga2.Version,
-		int64(env.Icinga2.ProgramStart*1000),
-		utils.Bool[env.Icinga2.NotificationsEnabled],
-		utils.Bool[env.Icinga2.ActiveServiceChecksEnabled],
-		utils.Bool[env.Icinga2.ActiveHostChecksEnabled],
-		utils.Bool[env.Icinga2.EventHandlersEnabled],
-		utils.Bool[env.Icinga2.FlapDetectionEnabled],
-		utils.Bool[env.Icinga2.PerformanceDataEnabled],
-	)
-	return err
-}
-
-func (h *HA) getInstance() (bool, uuid.UUID, int64, error) {
-	rows, err := h.super.Dbw.SqlFetchAll(
-		mysqlObservers.selectIdHeartbeatFromIcingadbInstanceByEnvironmentId,
-		"SELECT id, heartbeat from icingadb_instance where environment_id = ? LIMIT 1",
-		h.super.EnvId,
-	)
-
 	if err != nil {
-		return false, uuid.UUID{}, 0, err
+		return false, uuid.UUID{}, err
 	}
+	if len(rows) > 1 {
+		return false, uuid.UUID{}, errors.New("there is more than one active IcingaDB instance")
+	}
+
 	if len(rows) == 0 {
-		return false, uuid.UUID{}, 0, nil
+		// No active instance according to database.
+		return false, uuid.UUID{}, nil
 	}
 
-	var theirUUID uuid.UUID
-	copy(theirUUID[:], rows[0][0].([]byte))
+	idBytes := rows[0][0].([]byte)
+	icinga2Heartbeat := rows[0][1].(int64)
 
-	return true, theirUUID, rows[0][1].(int64), nil
+	activeId, err := uuid.FromBytes(idBytes)
+	if err != nil {
+		return false, uuid.UUID{}, fmt.Errorf("invalid active UUID in database: %s", err.Error())
+	}
+
+	icinga2HeartbeatAge := utils.TimeToMillisecs(time.Now()) - icinga2Heartbeat
+
+	if activeId == h.uid && icinga2HeartbeatAge > heartbeatValidMillisecs {
+		// Our heartbeat is too old to be considered valid, no longer consider ourselves to be active.
+		return false, uuid.UUID{}, nil
+	} else if activeId != h.uid && icinga2HeartbeatAge > heartbeatTimeoutMillisecs {
+		// Their heartbeat is old enough to be considered timed out, no longer consider them to be active.
+		return false, uuid.UUID{}, nil
+	}
+
+	return true, activeId, nil
 }
 
 func (h *HA) StartHA(chEnv chan *Environment) {
 	env := h.waitForEnvironment(chEnv)
+	h.lastHeartbeat = utils.TimeToMillisecs(time.Now())
 	err := h.setAndInsertEnvironment(env)
 	if err != nil {
-		h.super.ChErr <- fmt.Errorf("Could not insert environment into MySQL: %s", err.Error())
+		h.super.ChErr <- fmt.Errorf("could not insert environment into MySQL: %s", err.Error())
 	}
 
 	h.logger = log.WithFields(log.Fields{
@@ -189,13 +182,7 @@ func (h *HA) StartHA(chEnv chan *Environment) {
 
 	h.logger.Info("Got initial environment.")
 
-	h.checkResponsibility(env)
-
-	h.heartbeatTimer = time.NewTimer(time.Second * 15)
-
-	for {
-		h.runHA(chEnv)
-	}
+	h.runHA(chEnv, env)
 }
 
 func (h *HA) waitForEnvironment(chEnv chan *Environment) *Environment {
@@ -225,90 +212,81 @@ func (h *HA) setAndInsertEnvironment(env *Environment) error {
 }
 
 func (h *HA) checkResponsibility(env *Environment) {
-	found, _, beat, err := h.getInstance()
-	if err != nil {
-		h.logger.Errorf("Failed to fetch instance: %v", err)
-		h.super.ChErr <- errors.New("failed to fetch instance")
-		return
-	}
-
-	if utils.TimeToMillisecs(time.Now())-beat > 15*1000 {
-		h.logger.Info("Taking over.")
-
-		// This means there was no instance row match, insert
-		if !found {
-			err = h.insertInstance(env)
-		} else {
-			err = h.takeOverInstance(env)
-		}
-
+	var newState State
+	err := h.super.Dbw.SqlTransaction(true, false, false, func(tx connection.DbTransaction) error {
+		foundActive, activeId, err := h.getActiveInstance(tx)
 		if err != nil {
-			h.logger.Errorf("Failed to insert/update instance: %v", err)
-			h.super.ChErr <- errors.New("failed to insert/update instance")
-			return
+			return err
 		}
 
-		h.setState(StateActive)
-	} else {
-		h.logger.Info("Other instance is active.")
-		h.setState(StateOtherActive)
+		lastIcinga2HeartbeatAge := utils.TimeToMillisecs(time.Now()) - h.lastHeartbeat
+		lastIcinga2HeartbeatValid := lastIcinga2HeartbeatAge < heartbeatValidMillisecs
+
+		if foundActive {
+			if activeId == h.uid {
+				if lastIcinga2HeartbeatValid {
+					// We are active according to the DB and have a valid heartbeat, keep it that way.
+					newState = StateActive
+				} else {
+					// We are active according to the DB but our heartbeat from Icinga 2 is no longer valid.
+					// Give up active state so that another instance has a chance to take over.
+					newState = StateAllInactive
+				}
+			} else {
+				// Some other instance is active, remain passive
+				newState = StateOtherActive
+			}
+		} else {
+			// No instance is currently active. Try take over, but only
+			// if we are actively receiving heartbeats from Icinga 2.
+			if lastIcinga2HeartbeatValid {
+				h.logger.Info("No active instance, trying to take over.")
+				newState = StateActive
+			} else {
+				newState = StateAllInactive
+			}
+		}
+
+		err = h.upsertInstance(tx, env, newState == StateActive)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+	if err != nil {
+		// Transaction failed, we are not sure about the current global state.
+		// In any case, we ensure that we are no longer active.
+		h.super.ChErr <- errors.New("HA heartbeat failed")
+		h.logger.Errorf("HA heartbeat failed: %s", err.Error())
+		newState = StateInactiveUnkown
 	}
+	h.setState(newState)
 }
 
-func (h *HA) runHA(chEnv chan *Environment) {
-	select {
-	case env := <-chEnv:
-		if bytes.Compare(env.ID, h.super.EnvId) != 0 {
-			h.logger.Error("Received environment is not the one we expected. Panic.")
-			h.super.ChErr <- errors.New("received unexpected environment")
-			return
-		}
+func (h *HA) runHA(chEnv chan *Environment, env *Environment) {
+	// Force regular Icinga DB heartbeat writes to the database even if we receive no heartbeats from
+	// Icinga 2. Icinga 2 will send an heartbeat every second, so use two seconds here to avoid
+	// situations like forcing the update right before we receive the next heartbeat from Icinga 2.
+	const updateTimerDuration = 2 * time.Second
 
-		h.heartbeatTimer.Reset(time.Second * 15)
-		previous := h.lastHeartbeat
-		h.lastHeartbeat = utils.TimeToMillisecs(time.Now())
+	updateTimer := time.NewTimer(updateTimerDuration)
 
-		if h.lastHeartbeat-previous < 10*1000 && h.state == StateActive {
-			err := h.updateOwnInstance(env)
-
-			if err != nil {
-				h.logger.Errorf("Failed to update instance: %v", err)
-				h.super.ChErr <- errors.New("failed to update instance")
+	for {
+		select {
+		case env = <-chEnv:
+			if bytes.Compare(env.ID, h.super.EnvId) != 0 {
+				h.logger.Error("Received environment is not the one we expected. Panic.")
+				h.super.ChErr <- errors.New("received unexpected environment")
 				return
 			}
-		} else {
-			_, they, beat, err := h.getInstance()
-			if err != nil {
-				h.logger.Errorf("Failed to fetch instance: %v", err)
-				h.super.ChErr <- errors.New("failed to fetch instance")
-				return
-			}
-			if they == h.uid {
-				h.logger.Debug("We are active.")
-				if h.state != StateActive {
-					h.logger.Info("Icinga 2 sent heartbeat. Starting sync")
-					h.setState(StateActive)
-				}
-
-				if err := h.updateOwnInstance(env); err != nil {
-					h.logger.Errorf("Failed to update instance: %v", err)
-					h.super.ChErr <- errors.New("failed to update instance")
-					return
-				}
-			} else if h.lastHeartbeat-beat > 15*1000 {
-				h.logger.Info("Taking over.")
-				if err := h.takeOverInstance(env); err != nil {
-					h.logger.Errorf("Failed to update instance: %v", err)
-					h.super.ChErr <- errors.New("failed to update instance")
-				}
-				h.setState(StateActive)
-			} else {
-				h.logger.Debug("Other instance is active.")
-			}
+			h.lastHeartbeat = utils.TimeToMillisecs(time.Now())
+		case <-updateTimer.C: // force update
 		}
-	case <-h.heartbeatTimer.C:
-		h.logger.Info("Icinga 2 sent no heartbeat for 15 seconds. Pausing sync")
-		h.setState(StateAllInactive)
+
+		updateTimer.Reset(updateTimerDuration)
+
+		h.checkResponsibility(env)
 	}
 }
 

--- a/ha/ha_test.go
+++ b/ha/ha_test.go
@@ -20,14 +20,11 @@ import (
 )
 
 func createTestingHA(t *testing.T, redisAddr string) *HA {
-	redisConn := connection.NewRDBWrapper(redisAddr, "", 64)
-
 	mysqlConn, err := connection.NewDBWrapper(testbackends.MysqlTestDsn, 50)
 	require.NoError(t, err, "This test needs a working MySQL connection!")
 
 	super := supervisor.Supervisor{
 		ChErr: make(chan error),
-		Rdbw:  redisConn,
 		Dbw:   mysqlConn,
 	}
 
@@ -50,8 +47,6 @@ func createTestingHA(t *testing.T, redisAddr string) *HA {
 }
 
 func createTestingMultipleHA(t *testing.T, redisAddr string, numInstances int) ([]*HA, <-chan error) {
-	redisConn := connection.NewRDBWrapper(redisAddr, "", 64)
-
 	mysqlConn, err := connection.NewDBWrapper(testbackends.MysqlTestDsn, 50)
 	require.NoError(t, err, "This test needs a working MySQL connection!")
 
@@ -65,7 +60,6 @@ func createTestingMultipleHA(t *testing.T, redisAddr string, numInstances int) (
 
 		super := supervisor.Supervisor{
 			ChErr: chErr,
-			Rdbw:  redisConn,
 			Dbw:   mysqlConn,
 		}
 

--- a/ha/heartbeat.go
+++ b/ha/heartbeat.go
@@ -5,12 +5,10 @@ package ha
 import (
 	"crypto/sha1"
 	"encoding/json"
-	"fmt"
 	"github.com/Icinga/icingadb/connection"
 	"github.com/Icinga/icingadb/utils"
 	"github.com/go-redis/redis/v7"
 	log "github.com/sirupsen/logrus"
-	"time"
 )
 
 type Environment struct {
@@ -43,7 +41,7 @@ func IcingaHeartbeatListener(rdb *connection.RDBWrapper, chEnv chan *Environment
 	log.Info("Starting heartbeat listener")
 
 	xReadArgs := redis.XReadArgs{
-		Streams: []string{"icinga:stats", fmt.Sprintf("%d-0", utils.TimeToMillisecs(time.Now().Add(-15*time.Second)))},
+		Streams: []string{"icinga:stats", "$"},
 		Count:   1,
 		Block:   0,
 	}

--- a/ha/state.go
+++ b/ha/state.go
@@ -1,0 +1,28 @@
+package ha
+
+type State uint8
+
+const (
+	StateInit           State = iota // Initial state when starting
+	StateActive                      // This instance is active
+	StateOtherActive                 // This instance is inactive but there is another one that is active
+	StateAllInactive                 // All known instances are inactive (i.e. none receives Icinga 2 heartbeats)
+	StateInactiveUnkown              // This instance is inactive but does not known about the state of other instances
+)
+
+func (s State) String() string {
+	switch s {
+	case StateInit:
+		return "init"
+	case StateActive:
+		return "active"
+	case StateOtherActive:
+		return "inactive (other instance active)"
+	case StateAllInactive:
+		return "inactive (all instances inactive)"
+	case StateInactiveUnkown:
+		return "inactive (other instances unkown)"
+	default:
+		return "(invalid)"
+	}
+}

--- a/main.go
+++ b/main.go
@@ -106,6 +106,7 @@ func main() {
 	metricsInfo := config.GetMetricsInfo()
 
 	redisConn := connection.NewRDBWrapper(redisInfo.Host+":"+redisInfo.Port, redisInfo.Password, redisInfo.PoolSize)
+	redisConnHa := connection.NewRDBWrapper(redisInfo.Host+":"+redisInfo.Port, redisInfo.Password, 1)
 
 	var dbDSN string
 	if filepath.IsAbs(mysqlInfo.Host) {
@@ -135,7 +136,7 @@ func main() {
 	}
 
 	go haInstance.StartHA(chEnv)
-	go ha.IcingaHeartbeatListener(redisConn, chEnv, super.ChErr)
+	go ha.IcingaHeartbeatListener(redisConnHa, chEnv, super.ChErr)
 
 	go jsondecoder.DecodePool(super.ChDecode, super.ChErr, 16)
 

--- a/main.go
+++ b/main.go
@@ -119,6 +119,10 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+	mysqlConnHa, err := connection.NewDBWrapper(dbDSN, 1)
+	if err != nil {
+		log.Fatal(err)
+	}
 
 	super := supervisor.Supervisor{
 		ChErr:        make(chan error),
@@ -130,7 +134,7 @@ func main() {
 	}
 
 	chEnv := make(chan *ha.Environment)
-	haInstance, err := ha.NewHA(&super)
+	haInstance, err := ha.NewHA(&super, mysqlConnHa)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Make the HA takeover mechanism concurrency-safe. The general idea is to insert a row into `icingadb_instance` for each instance that reflects the responsible status of the instance. When trying to take over, a serializable SQL transaction is used to check the status of all other instances and update the current instance to the responsible state.

The PR also moves some code from the `ha` package to `configobject/configsync` which was very specific to the config sync and instead provides a generic mechanism to get notified about HA state changes in the `ha` package.

### Schema changes
* Change type of `icingadb_instance.id` from `binary(16)` to `binary(20)`: it now stores a SHA1 hash instead of an UUID
* Introduce a column `icingadb_instance.startup_id`: detect multiple instances sharing the same ID by accident

### TODO

* [x] Prevent `icingadb_instance` table from growing as each startup currently inserts a new row: Persistent instance ID (<s>config file? state dir?</s> `SHA1(environment.name + endpoint.name)` as ID)
* [ ] Icinga Web 2 currently doesn't handle multiple rows in `icingadb_instance` properly with the current schema, see also #234
  Workaround for now: `docker-compose exec --user 0 web sed -i 's/responsible desc/responsible asc/' /usr/share/icingaweb2/modules/icingadb/library/Icingadb/Model/Instance.php`

fixes #229
fixes #214