### PR TITLE
Make overdue sync HA-aware

### DIFF
--- a/configobject/statesync/statesync.go
+++ b/configobject/statesync/statesync.go
@@ -5,6 +5,7 @@ package statesync
 import (
 	"encoding/hex"
 	"github.com/Icinga/icingadb/connection"
+	"github.com/Icinga/icingadb/ha"
 	"github.com/Icinga/icingadb/supervisor"
 	"github.com/Icinga/icingadb/utils"
 	"github.com/go-redis/redis/v7"
@@ -33,8 +34,8 @@ var mysqlObservers = struct {
 }
 
 // StartStateSync starts the sync goroutines for hosts and services.
-func StartStateSync(super *supervisor.Supervisor) {
-	startOverdueSync(super)
+func StartStateSync(super *supervisor.Supervisor, haInstance *ha.HA) {
+	startOverdueSync(super, haInstance)
 
 	go func() {
 		for {

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func main() {
 
 	startConfigSyncOperators(&super, haInstance)
 
-	statesync.StartStateSync(&super)
+	statesync.StartStateSync(&super, haInstance)
 
 	history.StartHistoryWorkers(&super)
 


### PR DESCRIPTION
Syncing the overdue flag to the host_state and service_state tables was not HA-aware and assumed to have a consistent copy of all serivces/hosts with overdue set stored in Redis. However, if a second Icinga DB instance was active, this set might have become outdated.

This commit fixes this by making the overdue sync HA-aware, i.e. pausing it if the current instance is inactive. Additionally, it fetches the set of overdue services from MySQL and syncs it back to Redis when becoming active.

fixes #197
fixes #233

### Tests
* Removing left-over overdue flags:
    1. `UPDATE service_state SET is_overdue = 'y';`
    2. Verify that all services show up as overdue in the web interface
    3. Restart the active Icinga DB instance
    4. Verify that all all superfluous overdue states are gone
* Adding missing overdue flags:
    1. Ensure there are some overdue services, e.g. by taking down a satellite zone
    2. `UPDATE service_state SET is_overdue = 'n';`
    3. Verify that services which are actually overdue no longer show up as overdue in the web interface
    4. Restart the active Icinga DB instance
    5. Verify that the overdue services show up as overdue again
* No overdue when a single Icinga 2 master is gone:
    1. Stop the Icinga 2 master that is the data source for the currently active Icinga 2 instance
    2. Wait a bit and verify that no services are marked as overdue that shouldn't
    ```
    icingadb-2_1       | time="2020-12-22T08:29:56Z" level=info msg="Changing HA state to inactive (all instances inactive) (was active)"
    icingadb-2_1       | time="2020-12-22T08:29:56Z" level=info msg="HA became inactive, stopping service overdue sync"
    icingadb-2_1       | time="2020-12-22T08:29:56Z" level=info msg="Waiting for HA to become active before (re)starting service overdue sync"
    icingadb-2_1       | time="2020-12-22T08:29:56Z" level=info msg="HA became inactive, stopping host overdue sync"
    icingadb-2_1       | time="2020-12-22T08:29:56Z" level=info msg="Waiting for HA to become active before (re)starting host overdue sync"
    icingadb-1_1       | time="2020-12-22T08:29:56Z" level=info msg="No active instance, trying to take over." UUID=2b80ea30-b84a-4d4f-b6af-d2bc82e4c3e5 context=HA environment=da39a3ee5e6b4b0d3255bfef95601890afd80709
    icingadb-1_1       | time="2020-12-22T08:29:56Z" level=info msg="Changing HA state to active (was inactive (other instance active))"
    icingadb-1_1       | time="2020-12-22T08:29:56Z" level=info msg="HA became active, starting service overdue sync"
    icingadb-1_1       | time="2020-12-22T08:29:56Z" level=info msg="HA became active, starting host overdue sync"
    icingadb-2_1       | time="2020-12-22T08:29:58Z" level=info msg="Changing HA state to inactive (other instance active) (was inactive (all instances inactive))"
    ```

### Blocked By
* [x] depends on #232 which should be merged before
* [x] rebase onto current version of #232