### PR TITLE
Change output, long_output and performance_data columns to mediumtext

### DIFF
--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -129,9 +129,9 @@ CREATE TABLE host_state (
   attempt tinyint unsigned NOT NULL,
   severity smallint unsigned NOT NULL,
 
-  output text DEFAULT NULL,
-  long_output text DEFAULT NULL,
-  performance_data text DEFAULT NULL,
+  output mediumtext DEFAULT NULL,
+  long_output mediumtext DEFAULT NULL,
+  performance_data mediumtext DEFAULT NULL,
   check_commandline text DEFAULT NULL,
 
   is_problem enum('n', 'y') NOT NULL,
@@ -280,9 +280,9 @@ CREATE TABLE service_state (
   attempt tinyint unsigned NOT NULL,
   severity smallint unsigned NOT NULL,
 
-  output text DEFAULT NULL,
-  long_output text DEFAULT NULL,
-  performance_data text DEFAULT NULL,
+  output mediumtext DEFAULT NULL,
+  long_output mediumtext DEFAULT NULL,
+  performance_data mediumtext DEFAULT NULL,
   check_commandline text DEFAULT NULL,
 
   is_problem enum('n', 'y') NOT NULL,
@@ -924,8 +924,8 @@ CREATE TABLE state_history (
   previous_soft_state tinyint unsigned NOT NULL,
   previous_hard_state tinyint unsigned NOT NULL,
   attempt tinyint unsigned NOT NULL,
-  output text DEFAULT NULL,
-  long_output text DEFAULT NULL,
+  output mediumtext DEFAULT NULL,
+  long_output mediumtext DEFAULT NULL,
   max_check_attempts int unsigned NOT NULL,
   check_source text DEFAULT NULL,
 

--- a/schema/mysql/upgrades/1.0.0-rc2.sql
+++ b/schema/mysql/upgrades/1.0.0-rc2.sql
@@ -110,3 +110,17 @@ ALTER TABLE acknowledgement_history
 
 INSERT INTO icingadb_schema (version, timestamp)
   VALUES (2, CURRENT_TIMESTAMP() * 1000);
+
+ALTER TABLE host_state
+    MODIFY output mediumtext DEFAULT NULL,
+    MODIFY long_output mediumtext DEFAULT NULL,
+    MODIFY performance_data mediumtext DEFAULT NULL;
+
+ALTER TABLE state_history
+    MODIFY output mediumtext DEFAULT NULL,
+    MODIFY long_output mediumtext DEFAULT NULL;
+
+ALTER TABLE service_state
+    MODIFY output mediumtext DEFAULT NULL,
+    MODIFY long_output mediumtext DEFAULT NULL,
+    MODIFY performance_data mediumtext DEFAULT NULL;


### PR DESCRIPTION
`mediumtext` is a tradeoff between `text` and `longtext`; `text` being too short and `longtext` being too big.
fixes #199 