### PR TITLE
Config Sync: Iterate over config using cursor (replace HKEYS with HSCAN)

### DIFF
--- a/configobject/configsync/configsync.go
+++ b/configobject/configsync/configsync.go
@@ -36,19 +36,19 @@ func Operator(super *supervisor.Supervisor, chHA chan int, objectInformation *co
 		done chan struct{}
 		// Used by this Operator to provide the InsertPrepWorker with IDs to insert
 		// Operator -> InsertPrepWorker
-		chInsert chan []string
+		chInsert chan *connection.ConfigChunk
 		// Used by the JsonDecodePool to provide the InsertExecWorker with decoded rows, ready to be inserted
 		// JsonDecodePool -> InsertExecWorker
 		chInsertBack chan []connection.Row
 		// Used by this Operator to provide the DeleteExecWorker with IDs to delete
 		// Operator -> DeleteExecWorker
-		chDelete chan []string
+		chDelete chan *connection.ConfigChunk
 		// Used by this Operator to provide the UpdateCompWorker with IDs to compare
 		// Operator -> UpdateCompWorker
-		chUpdateComp chan []string
+		chUpdateComp chan *connection.ConfigChunk
 		// Used by the UpdateCompWorker to provide the UpdatePrepWorker with IDs that have to be updated
 		// UpdateCompWorker -> UpdatePrepWorker
-		chUpdate chan []string
+		chUpdate chan *connection.ConfigChunk
 		// Used by the JsonDecodePool to provide the UpdateExecWorker with decoded rows, ready to be updated
 		// JsonDecodePool -> UpdateExecWorker
 		chUpdateBack chan []connection.Row
@@ -77,16 +77,16 @@ func Operator(super *supervisor.Supervisor, chHA chan int, objectInformation *co
 			log.Debugf("%s: Got responsibility", objectInformation.ObjectType)
 
 			//TODO: This should only be done, if HA was taken over from another instance
-			insert, update, delete := GetDelta(super, objectInformation)
-			//log.Infof("%s - Delta: (Insert: %d, Maybe Update: %d, Delete: %d)", objectInformation.ObjectType, len(insert), len(update), len(delete))
+			ins, upd, del := GetDelta(super, objectInformation)
+			//log.Infof("%s - Delta: (Insert: %d, Maybe Update: %d, Delete: %d)", objectInformation.ObjectType, len(ins), len(upd), len(del))
 
 			// Clean up all channels and wait groups for a fresh config dump
 			done = make(chan struct{})
-			chInsert = make(chan []string)
+			chInsert = make(chan *connection.ConfigChunk)
 			chInsertBack = make(chan []connection.Row)
-			chDelete = make(chan []string)
-			chUpdateComp = make(chan []string)
-			chUpdate = make(chan []string)
+			chDelete = make(chan *connection.ConfigChunk)
+			chUpdateComp = make(chan *connection.ConfigChunk)
+			chUpdate = make(chan *connection.ConfigChunk)
 			chUpdateBack = make(chan []connection.Row)
 			wgInsert = &sync.WaitGroup{}
 			wgDelete = &sync.WaitGroup{}
@@ -124,21 +124,21 @@ func Operator(super *supervisor.Supervisor, chHA chan int, objectInformation *co
 				defer super.WgConfigSync.Done()
 
 				benchmarc := utils.NewBenchmark()
-				wgInsert.Add(len(insert))
+				wgInsert.Add(len(ins.Keys))
 
 				// Provide the InsertPrepWorker with IDs to insert
-				chInsert <- insert
+				chInsert <- ins
 
 				// Wait for all IDs to be inserted into MySQL
 				kill := waitOrKill(wgInsert, done)
 				benchmarc.Stop()
-				if !kill && len(insert) > 0 {
+				if !kill && len(ins.Keys) > 0 {
 					log.WithFields(log.Fields{
 						"type":      objectInformation.ObjectType,
-						"count":     len(insert),
+						"count":     len(ins.Keys),
 						"benchmark": benchmarc.String(),
 						"action":    "insert",
-					}).Infof("Inserted %v %ss in %v", len(insert), objectInformation.ObjectType, benchmarc.String())
+					}).Infof("Inserted %v %ss in %v", len(ins.Keys), objectInformation.ObjectType, benchmarc.String())
 				}
 			}()
 
@@ -146,21 +146,22 @@ func Operator(super *supervisor.Supervisor, chHA chan int, objectInformation *co
 				defer super.WgConfigSync.Done()
 
 				benchmarc := utils.NewBenchmark()
-				wgDelete.Add(len(delete))
+				wgDelete.Add(len(del.Keys))
 
 				// Provide the DeleteExecWorker with IDs to delete
-				chDelete <- delete
+				chDelete <- del
 
 				// Wait for all IDs to be deleted from MySQL
 				kill := waitOrKill(wgDelete, done)
 				benchmarc.Stop()
-				if !kill && len(delete) > 0 {
+				if !kill && len(del.Keys) > 0 {
 					log.WithFields(log.Fields{
 						"type":      objectInformation.ObjectType,
-						"count":     len(delete),
+						"count":     len(del.Keys),
 						"benchmark": benchmarc.String(),
 						"action":    "delete",
-					}).Infof("Deleted %v %ss in %v", len(delete), objectInformation.ObjectType, benchmarc.String())
+					}).Infof("Deleted %v %ss in %v", len(del.Keys),
+						objectInformation.ObjectType, benchmarc.String())
 				}
 			}()
 
@@ -169,10 +170,10 @@ func Operator(super *supervisor.Supervisor, chHA chan int, objectInformation *co
 					defer super.WgConfigSync.Done()
 
 					benchmarc := utils.NewBenchmark()
-					wgUpdate.Add(len(update))
+					wgUpdate.Add(len(upd.Keys))
 
-					// Provide the UpdateCompWorker with IDs to compare
-					chUpdateComp <- update
+					// Provide the UpdatePrepWorker with IDs to compare
+					chUpdateComp <- upd
 
 					// Wait for all IDs to be update in MySQL
 					kill := waitOrKill(wgUpdate, done)
@@ -196,15 +197,21 @@ func Operator(super *supervisor.Supervisor, chHA chan int, objectInformation *co
 }
 
 // GetDelta takes the ObjectInformation (host, service, checkcommand, etc.) and fetches the ids from MySQL and Redis. It
-// returns three string slices:
+// returns three *ConfigChunk:
 // 1. IDs which are in the Redis but not in the MySQL (to insert)
 // 2. IDs which are in both (to possibly update)
 // 3. IDs which are in the MySQL but not the Redis (to delete)
-func GetDelta(super *supervisor.Supervisor, objectInformation *configobject.ObjectInformation) ([]string, []string, []string) {
+// All chunks have the Keys member set to a slice of IDs. The insert and update chunks additionally have either the
+// Checksums or the Configs member set. If the object type has checksums available, then Checksums is set, otherwise
+// Configs.
+func GetDelta(super *supervisor.Supervisor, objectInformation *configobject.ObjectInformation) (
+	ins *connection.ConfigChunk, upd *connection.ConfigChunk, del *connection.ConfigChunk) {
+
 	var (
-		redisIds []string
-		mysqlIds []string
-		wg       = sync.WaitGroup{}
+		redisIds  []string
+		mysqlIds  []string
+		allValues = make(map[string]string)
+		wg        = sync.WaitGroup{}
 	)
 
 	//get ids from redis
@@ -212,27 +219,37 @@ func GetDelta(super *supervisor.Supervisor, objectInformation *configobject.Obje
 	go func() {
 		defer wg.Done()
 
-		key := fmt.Sprintf("icinga:config:%s", objectInformation.RedisKey)
+		var key string
+		if objectInformation.HasChecksum {
+			key = fmt.Sprintf("icinga:checksum:%s", objectInformation.RedisKey)
+		} else {
+			key = fmt.Sprintf("icinga:config:%s", objectInformation.RedisKey)
+		}
 		cursor := uint64(0)
 
-		// Redis HSCAN may return duplicate results, use a map to remove duplicates.
-		idHash := make(map[string]bool)
-
 		iter := super.Rdbw.HScan(key, cursor, "", 1000).Iterator()
-		for i := 0; iter.Next(); i++ {
+		for iter.Next() {
 			// HScan returns a slice of alternating keys and values.
-			// As only the keys are needed, only consider even indices.
-			if i % 2 == 0 {
-				idHash[iter.Val()] = true
+			id := iter.Val()
+			if !iter.Next() {
+				if err := iter.Err(); err != nil {
+					super.ChErr <- err
+					return
+				} else {
+					super.ChErr <- fmt.Errorf("unexpected end of iterator while reading %s objects from Redis",
+						objectInformation.ObjectType)
+					return
+				}
 			}
+			allValues[id] = iter.Val()
 		}
 		if err := iter.Err(); err != nil {
 			super.ChErr <- err
 			return
 		}
 
-		redisIds = make([]string, 0, len(idHash))
-		for id, _ := range idHash {
+		redisIds = make([]string, 0, len(allValues))
+		for id := range allValues {
 			redisIds = append(redisIds, id)
 		}
 	}()
@@ -252,11 +269,31 @@ func GetDelta(super *supervisor.Supervisor, objectInformation *configobject.Obje
 	}()
 
 	wg.Wait()
-	return utils.Delta(redisIds, mysqlIds)
+	insIds, updIds, delIds := utils.Delta(redisIds, mysqlIds)
+
+	// Helper function to add either Checksums or Configs (depending on what was fetched by HScan) to a chunk.
+	addValues := func(chunk *connection.ConfigChunk) *connection.ConfigChunk {
+		values := make([]interface{}, len(chunk.Keys))
+		for i, key := range chunk.Keys {
+			values[i] = allValues[key]
+		}
+		if objectInformation.HasChecksum {
+			chunk.Checksums = values
+		} else {
+			chunk.Configs = values
+		}
+		return chunk
+	}
+
+	return addValues(&connection.ConfigChunk{Keys: insIds}),
+		addValues(&connection.ConfigChunk{Keys: updIds}),
+		&connection.ConfigChunk{Keys: delIds}
 }
 
 // InsertPrepWorker fetches config for IDs(chInsert) from Redis, wraps it into JsonDecodePackages and throws it into the JsonDecodePool
-func InsertPrepWorker(super *supervisor.Supervisor, objectInformation *configobject.ObjectInformation, done chan struct{}, chInsert <-chan []string, chInsertBack chan<- []connection.Row) {
+func InsertPrepWorker(super *supervisor.Supervisor, objectInformation *configobject.ObjectInformation,
+	done chan struct{}, chInsert <-chan *connection.ConfigChunk, chInsertBack chan<- []connection.Row) {
+
 	log.Debugf("%s: Insert preparation worker started", objectInformation.ObjectType)
 	defer log.Debugf("%s: Insert preparation worker stopped", objectInformation.ObjectType)
 
@@ -276,7 +313,7 @@ func InsertPrepWorker(super *supervisor.Supervisor, objectInformation *configobj
 				ObjectType: objectInformation.ObjectType,
 			}
 
-			if chunk.Checksums[i] != nil {
+			if chunk.Checksums != nil && chunk.Checksums[i] != nil {
 				pkg.ChecksumsRaw = chunk.Checksums[i].(string)
 			}
 
@@ -286,7 +323,7 @@ func InsertPrepWorker(super *supervisor.Supervisor, objectInformation *configobj
 		super.ChDecode <- &pkgs
 	}
 
-	for keys := range chInsert {
+	for chunk := range chInsert {
 		select {
 		case _, ok := <-done:
 			if !ok {
@@ -295,7 +332,14 @@ func InsertPrepWorker(super *supervisor.Supervisor, objectInformation *configobj
 		default:
 		}
 
-		ch := super.Rdbw.PipeConfigChunks(done, keys, objectInformation.RedisKey)
+		var flags connection.PipeConfigChunksFlags
+		if chunk.Configs == nil {
+			flags |= connection.FetchConfig
+		}
+		if objectInformation.HasChecksum && chunk.Checksums == nil {
+			flags |= connection.FetchChecksum
+		}
+		ch := super.Rdbw.PipeConfigChunks(done, objectInformation.RedisKey, chunk, flags)
 		go func() {
 			for chunk := range ch {
 				go prep(chunk)
@@ -328,11 +372,13 @@ func InsertExecWorker(super *supervisor.Supervisor, objectInformation *configobj
 }
 
 // DeleteExecWorker deletes IDs(chDelete) from MySQL
-func DeleteExecWorker(super *supervisor.Supervisor, objectInformation *configobject.ObjectInformation, done chan struct{}, chDelete <-chan []string, wg *sync.WaitGroup) {
+func DeleteExecWorker(super *supervisor.Supervisor, objectInformation *configobject.ObjectInformation,
+	done chan struct{}, chDelete <-chan *connection.ConfigChunk, wg *sync.WaitGroup) {
+
 	log.Debugf("%s: Delete execution worker started", objectInformation.ObjectType)
 	defer log.Debugf("%s: Delete execution worker stopped", objectInformation.ObjectType)
 
-	for keys := range chDelete {
+	for chunk := range chDelete {
 		select {
 		case _, ok := <-done:
 			if !ok {
@@ -346,18 +392,21 @@ func DeleteExecWorker(super *supervisor.Supervisor, objectInformation *configobj
 			rowLen := len(keys)
 			wg.Add(-rowLen)
 			ConfigSyncDeletesTotal.WithLabelValues(objectInformation.ObjectType).Add(float64(rowLen))
-		}(keys)
+		}(chunk.Keys)
 	}
 }
 
-// UpdateCompWorker gets IDs(chUpdateComp) that might need an update, fetches the corresponding checksums for Redis and MySQL,
-// compares them and inserts changed IDs into chUpdate.
-func UpdateCompWorker(super *supervisor.Supervisor, objectInformation *configobject.ObjectInformation, done chan struct{}, chUpdateComp <-chan []string, chUpdate chan<- []string, wg *sync.WaitGroup) {
+// UpdateCompWorker gets IDs(chUpdateComp) that might need an update, fetches the corresponding checksums for Redis and
+// MySQL, compares them and inserts changed IDs into chUpdate.
+func UpdateCompWorker(super *supervisor.Supervisor, objectInformation *configobject.ObjectInformation,
+	done chan struct{}, chUpdateComp <-chan *connection.ConfigChunk, chUpdate chan<- *connection.ConfigChunk,
+	wg *sync.WaitGroup) {
+
 	log.Debugf("%s: Update comparison worker started", objectInformation.ObjectType)
 	defer log.Debugf("%s: Update comparison worker stopped", objectInformation.ObjectType)
 
-	prep := func(chunk *connection.ChecksumChunk, mysqlChecksums map[string]map[string]string) {
-		changed := make([]string, 0)
+	prep := func(chunk *connection.ConfigChunk, mysqlChecksums map[string]map[string]string) {
+		changed := new(connection.ConfigChunk)
 		for i, key := range chunk.Keys {
 			if chunk.Checksums[i] == nil {
 				continue
@@ -371,7 +420,11 @@ func UpdateCompWorker(super *supervisor.Supervisor, objectInformation *configobj
 			}
 
 			if redisChecksums.PropertiesChecksum != mysqlChecksums[key]["properties_checksum"] {
-				changed = append(changed, key)
+				changed.Keys = append(changed.Keys, key)
+				changed.Checksums = append(changed.Configs, chunk.Checksums[i])
+				if chunk.Configs != nil {
+					changed.Configs = append(changed.Configs, chunk.Configs[i])
+				}
 			} else {
 				wg.Done()
 			}
@@ -379,7 +432,7 @@ func UpdateCompWorker(super *supervisor.Supervisor, objectInformation *configobj
 		chUpdate <- changed
 	}
 
-	for keys := range chUpdateComp {
+	for chunk := range chUpdateComp {
 		select {
 		case _, ok := <-done:
 			if !ok {
@@ -388,8 +441,12 @@ func UpdateCompWorker(super *supervisor.Supervisor, objectInformation *configobj
 		default:
 		}
 
-		ch := super.Rdbw.PipeChecksumChunks(done, keys, objectInformation.RedisKey)
-		checksums, err := super.Dbw.SqlFetchChecksums(objectInformation.ObjectType, keys)
+		var flags connection.PipeConfigChunksFlags
+		if chunk.Checksums == nil {
+			flags |= connection.FetchChecksum
+		}
+		ch := super.Rdbw.PipeConfigChunks(done, objectInformation.RedisKey, chunk, flags)
+		checksums, err := super.Dbw.SqlFetchChecksums(objectInformation.ObjectType, chunk.Keys)
 		if err != nil {
 			super.ChErr <- err
 		}
@@ -403,7 +460,9 @@ func UpdateCompWorker(super *supervisor.Supervisor, objectInformation *configobj
 }
 
 // UpdatePrepWorker fetches config for IDs(chUpdate) from Redis, wraps it into JsonDecodePackages and throws it into the JsonDecodePool
-func UpdatePrepWorker(super *supervisor.Supervisor, objectInformation *configobject.ObjectInformation, done chan struct{}, chUpdate <-chan []string, chUpdateBack chan<- []connection.Row) {
+func UpdatePrepWorker(super *supervisor.Supervisor, objectInformation *configobject.ObjectInformation,
+	done chan struct{}, chUpdate <-chan *connection.ConfigChunk, chUpdateBack chan<- []connection.Row) {
+
 	log.Debugf("%s: Update preparation worker started", objectInformation.ObjectType)
 	defer log.Debugf("%s: Update preparation worker stopped", objectInformation.ObjectType)
 
@@ -428,7 +487,7 @@ func UpdatePrepWorker(super *supervisor.Supervisor, objectInformation *configobj
 		super.ChDecode <- &pkgs
 	}
 
-	for keys := range chUpdate {
+	for chunk := range chUpdate {
 		select {
 		case _, ok := <-done:
 			if !ok {
@@ -437,7 +496,14 @@ func UpdatePrepWorker(super *supervisor.Supervisor, objectInformation *configobj
 		default:
 		}
 
-		ch := super.Rdbw.PipeConfigChunks(done, keys, objectInformation.RedisKey)
+		var flags connection.PipeConfigChunksFlags
+		if chunk.Configs == nil {
+			flags |= connection.FetchConfig
+		}
+		if objectInformation.HasChecksum && chunk.Checksums == nil {
+			flags |= connection.FetchChecksum
+		}
+		ch := super.Rdbw.PipeConfigChunks(done, objectInformation.RedisKey, chunk, flags)
 		go func() {
 			for chunk := range ch {
 				go prep(chunk)
@@ -447,7 +513,9 @@ func UpdatePrepWorker(super *supervisor.Supervisor, objectInformation *configobj
 }
 
 // UpdateExecWorker gets decoded connection.Row objects from the JsonDecodePool and updates them in MySQL
-func UpdateExecWorker(super *supervisor.Supervisor, objectInformation *configobject.ObjectInformation, done chan struct{}, chUpdateBack <-chan []connection.Row, wg *sync.WaitGroup, updateCounter *uint32) {
+func UpdateExecWorker(super *supervisor.Supervisor, objectInformation *configobject.ObjectInformation,
+	done chan struct{}, chUpdateBack <-chan []connection.Row, wg *sync.WaitGroup, updateCounter *uint32) {
+
 	log.Debugf("%s: Update execution worker started", objectInformation.ObjectType)
 	defer log.Debugf("%s: Update execution worker stopped", objectInformation.ObjectType)
 
@@ -470,7 +538,11 @@ func UpdateExecWorker(super *supervisor.Supervisor, objectInformation *configobj
 	}
 }
 
-func RuntimeUpdateWorker(super *supervisor.Supervisor, objectInformation *configobject.ObjectInformation, done chan struct{}, chInsert chan []string, chUpdate chan []string, chDelete chan []string, wgInsert *sync.WaitGroup, wgUpdate *sync.WaitGroup, wgDelete *sync.WaitGroup) {
+func RuntimeUpdateWorker(super *supervisor.Supervisor, objectInformation *configobject.ObjectInformation,
+	done chan struct{}, chInsert chan *connection.ConfigChunk, chUpdate chan *connection.ConfigChunk,
+	chDelete chan *connection.ConfigChunk, wgInsert *sync.WaitGroup, wgUpdate *sync.WaitGroup,
+	wgDelete *sync.WaitGroup) {
+
 	subscription := super.Rdbw.Subscribe()
 	defer subscription.Close()
 
@@ -490,10 +562,10 @@ func RuntimeUpdateWorker(super *supervisor.Supervisor, objectInformation *config
 		updateLen := len(currentUpdatePackage)
 
 		if objectInformation.HasChecksum {
-			chUpdate <- currentUpdatePackage
+			chUpdate <- &connection.ConfigChunk{Keys: currentUpdatePackage}
 			wgUpdate.Add(updateLen)
 		} else {
-			chInsert <- currentUpdatePackage
+			chInsert <- &connection.ConfigChunk{Keys: currentUpdatePackage}
 			wgInsert.Add(updateLen)
 		}
 
@@ -507,7 +579,7 @@ func RuntimeUpdateWorker(super *supervisor.Supervisor, objectInformation *config
 
 	insertCurrentDeletePackage := func() {
 		deleteLen := len(currentDeletePackage)
-		chDelete <- currentDeletePackage
+		chDelete <- &connection.ConfigChunk{Keys: currentDeletePackage}
 		wgDelete.Add(deleteLen)
 		currentDeletePackage = []string{}
 

--- a/connection/redis.go
+++ b/connection/redis.go
@@ -557,38 +557,67 @@ type ConfigChunk struct {
 	Checksums []interface{}
 }
 
-type ChecksumChunk struct {
-	Keys      []string
-	Checksums []interface{}
-}
+type PipeConfigChunksFlags uint8
 
-func (rdbw *RDBWrapper) PipeConfigChunks(done <-chan struct{}, keys []string, redisKey string) <-chan *ConfigChunk {
+const (
+	FetchChecksum PipeConfigChunksFlags = 1 << iota
+	FetchConfig
+)
+
+func (rdbw *RDBWrapper) PipeConfigChunks(done <-chan struct{}, objType string, inChunk *ConfigChunk,
+	fetch PipeConfigChunksFlags) <-chan *ConfigChunk {
+
 	out := make(chan *ConfigChunk)
 
-	worker := func(chunk <-chan []string) {
-		for k := range chunk {
+	fetchChecksum := fetch&FetchChecksum == FetchChecksum
+	fetchConfig := fetch&FetchConfig == FetchConfig
+
+	if !fetchChecksum && !fetchConfig {
+		// Shortcut just forwarding the chunk if no information needs to be fetched.
+		go func() {
+			select {
+			case out <- inChunk:
+			case <-done:
+			}
+		}()
+
+		return out
+	}
+
+	worker := func(chChunk <-chan *ConfigChunk) {
+		for chunk := range chChunk {
 			pipe := rdbw.Pipeline()
 			cmds := make([]*redis.SliceCmd, 2)
 
-			cmds[0] = pipe.HMGet(fmt.Sprintf("icinga:config:%s", redisKey), k...)
-			cmds[1] = pipe.HMGet(fmt.Sprintf("icinga:checksum:%s", redisKey), k...)
+			// Checksums is the first query so that in the worst case, we read an older checksum
+			// than config and perform a redundant update than missing an update.
+			if fetchChecksum {
+				cmds[0] = pipe.HMGet(fmt.Sprintf("icinga:checksum:%s", objType), chunk.Keys...)
+			}
+			if fetchConfig {
+				cmds[1] = pipe.HMGet(fmt.Sprintf("icinga:config:%s", objType), chunk.Keys...)
+			}
 
 			_, err := pipe.Exec() // TODO(el): What to do with the Cmder slice?
 			if err != nil {
 				panic(err)
 			}
 
-			configs, err := cmds[0].Result()
-			if err != nil {
-				panic(err)
+			if fetchChecksum {
+				chunk.Checksums, err = cmds[0].Result()
+				if err != nil {
+					panic(err)
+				}
 			}
-			checksums, err := cmds[1].Result()
-			if err != nil {
-				panic(err)
+			if fetchConfig {
+				chunk.Configs, err = cmds[1].Result()
+				if err != nil {
+					panic(err)
+				}
 			}
 
 			select {
-			case out <- &ConfigChunk{Keys: k, Configs: configs, Checksums: checksums}:
+			case out <- chunk:
 			case <-done:
 				return
 			}
@@ -596,49 +625,26 @@ func (rdbw *RDBWrapper) PipeConfigChunks(done <-chan struct{}, keys []string, re
 	}
 
 	//TODO: Replace fixed chunkSize
-	work := utils.ChunkKeys(done, keys, 500)
+	chunkSize := 500
 
+	work := make(chan *ConfigChunk)
 	go func() {
-		defer close(out)
-
-		wg := &sync.WaitGroup{}
-
-		for i := 0; i < 32; i++ {
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				worker(work)
-			}()
-		}
-
-		wg.Wait()
-	}()
-
-	return out
-}
-
-func (rdbw *RDBWrapper) PipeChecksumChunks(done <-chan struct{}, keys []string, redisKey string) <-chan *ChecksumChunk {
-	out := make(chan *ChecksumChunk)
-
-	worker := func(chunk <-chan []string) {
-		for k := range chunk {
-			cmd := rdbw.HMGet(fmt.Sprintf("icinga:checksum:%s", redisKey), k...)
-
-			checksums, err := cmd.Result()
-			if err != nil {
-				panic(err)
+		defer close(work)
+		for _, c := range utils.ChunkIndices(len(inChunk.Keys), chunkSize) {
+			chunk := &ConfigChunk{Keys: inChunk.Keys[c.Begin:c.End]}
+			if inChunk.Configs != nil {
+				chunk.Configs = inChunk.Configs[c.Begin:c.End]
 			}
-
+			if inChunk.Checksums != nil {
+				chunk.Checksums = inChunk.Checksums[c.Begin:c.End]
+			}
 			select {
-			case out <- &ChecksumChunk{Keys: k, Checksums: checksums}:
+			case work <- chunk:
 			case <-done:
 				return
 			}
 		}
-	}
-
-	//TODO: Replace fixed chunkSize
-	work := utils.ChunkKeys(done, keys, 500)
+	}()
 
 	go func() {
 		defer close(out)

--- a/utils/chunks.go
+++ b/utils/chunks.go
@@ -32,13 +32,35 @@ func ChunkInterfaces(interfaces []interface{}, size int) [][]interface{} {
 	chunks := make([][]interface{}, chunksLen)
 
 	for i := 0; i < chunksLen; i++ {
-		start := i * size;
+		start := i * size
 		end := start + size
 		if end > len(interfaces) {
 			end = len(interfaces)
 		}
 
 		chunks[i] = interfaces[start:end]
+	}
+
+	return chunks
+}
+
+type Chunk struct {
+	Begin, End int
+}
+
+func ChunkIndices(total, chunk int) []Chunk {
+	n := total / chunk
+	if total%chunk > 0 {
+		n++
+	}
+
+	chunks := make([]Chunk, n)
+	for i := range chunks {
+		chunks[i].Begin = i * chunk
+		chunks[i].End = i*chunk + chunk
+		if chunks[i].End > total {
+			chunks[i].End = total
+		}
 	}
 
 	return chunks

--- a/utils/chunks_test.go
+++ b/utils/chunks_test.go
@@ -86,3 +86,21 @@ func TestChunkInterfaces(t *testing.T) {
 
 	assert.Equal(t, want, chunks)
 }
+
+func TestTestChunkIndices(t *testing.T) {
+	assert.Equal(t, 0, len(ChunkIndices(0, 1)), "chunking zero elements should return zero chunks")
+
+	assert.Equal(t, []Chunk{
+		{0, 10},
+		{10, 20},
+	}, ChunkIndices(20, 10), "chunking 20 elements into chunks of size 10")
+
+	assert.Equal(t, []Chunk{
+		{0, 23},
+	}, ChunkIndices(23, 42), "chunking 23 elements into chunks of size 42")
+
+	assert.Equal(t, []Chunk{
+		{0, 23},
+		{23, 42},
+	}, ChunkIndices(42, 23), "chunking 42 elements into chunks of size 23")
+}


### PR DESCRIPTION
Redis documentation states that it is preferable to use `*SCAN` instead of `*KEYS` (https://redis.io/commands/keys):

<blockquote>
Warning: consider KEYS as a command that should only be used in production environments with extreme care. It may ruin performance when it is executed against large databases. This command is intended for debugging and special operations, such as changing your keyspace layout.  Don't use KEYS in your regular application code. If you're looking for a way to find keys in a subset of your keyspace, consider using SCAN or sets.
</blockquote>

While the documentation is for the KEYS command and not HKEYS, the same warning should apply here to as the hashes we are iterating over can get quite large. Therefore use the HSCAN command that exists as an alternative.

In contrast to HKEYS, HSCAN not only returns the keys but also the values in the hash. Therefore now HSCAN is done on `icings:checksum:*` if available and on `icinga:config:*` otherwise. In both cases, the values are later reused.

## To be determined
* COUNT value for HSCAN: 1000? 2000? 10000? see https://github.com/Icinga/icingadb/pull/251#issuecomment-772458835