### PR TITLE
ChunkRows: replace float with int arithmetic

### DIFF
--- a/connection/mysql_utils.go
+++ b/connection/mysql_utils.go
@@ -10,7 +10,6 @@ import (
 	"github.com/go-sql-driver/mysql"
 	"io/ioutil"
 	oldlog "log"
-	"math"
 	"sort"
 	"strconv"
 	"strings"
@@ -426,11 +425,14 @@ type Row interface {
 type RowFactory func() Row
 
 func ChunkRows(rows []Row, size int) [][]Row {
-	chunksLen := int(math.Ceil(float64(len(rows)) / float64(size)))
+	chunksLen := len(rows) / size
+	if len(rows)%size != 0 {
+		chunksLen++
+	}
 	chunks := make([][]Row, chunksLen)
 
 	for i := 0; i < chunksLen; i++ {
-		start := i * size;
+		start := i * size
 		end := start + size
 		if end > len(rows) {
 			end = len(rows)


### PR DESCRIPTION
Avoiding float arithmetic avoids precision problems. I don't think this results in any bugs for values we realistically reach in Icinga DB, but why use floats if you don't have to? Then you also don't have to think about whether doing so may blow up.