### PR TITLE
Fix panic caused by incorrect chunks fed into PipeConfigChunks

### DIFF
--- a/configobject/configsync/configsync.go
+++ b/configobject/configsync/configsync.go
@@ -420,7 +420,7 @@ func UpdateCompWorker(super *supervisor.Supervisor, objectInformation *configobj
 
 			if redisChecksums.PropertiesChecksum != mysqlChecksums[key]["properties_checksum"] {
 				changed.Keys = append(changed.Keys, key)
-				changed.Checksums = append(changed.Configs, chunk.Checksums[i])
+				changed.Checksums = append(changed.Checksums, chunk.Checksums[i])
 				if chunk.Configs != nil {
 					changed.Configs = append(changed.Configs, chunk.Configs[i])
 				}


### PR DESCRIPTION
There was a copy paste error that results in a panic in `PipeConfigChunks` when updating config objects.

While I reviewed the code for similar mistakes, I also replaced `cmd[0]`/`cmd[1]` in `PipeConfigChunks` with separate variables to make the code there easier to check.

fixes #263
closes #264