### PR TITLE
MySQL schema: reverse order of entries in enums for boolean to fix sort order

### DIFF
--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -30,21 +30,21 @@ CREATE TABLE host (
   check_interval int unsigned NOT NULL,
   check_retry_interval int unsigned NOT NULL,
 
-  active_checks_enabled enum('y','n') NOT NULL,
-  passive_checks_enabled enum('y','n') NOT NULL,
-  event_handler_enabled enum('y','n') NOT NULL,
-  notifications_enabled enum('y','n') NOT NULL,
+  active_checks_enabled enum('n', 'y') NOT NULL,
+  passive_checks_enabled enum('n', 'y') NOT NULL,
+  event_handler_enabled enum('n', 'y') NOT NULL,
+  notifications_enabled enum('n', 'y') NOT NULL,
 
-  flapping_enabled enum('y','n') NOT NULL,
+  flapping_enabled enum('n', 'y') NOT NULL,
   flapping_threshold_low float NOT NULL,
   flapping_threshold_high float NOT NULL,
 
-  perfdata_enabled enum('y','n') NOT NULL,
+  perfdata_enabled enum('n', 'y') NOT NULL,
 
   eventcommand varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'eventcommand.name',
   eventcommand_id binary(20) DEFAULT NULL COMMENT 'eventcommand.id',
 
-  is_volatile enum('y','n') NOT NULL,
+  is_volatile enum('n', 'y') NOT NULL,
 
   action_url_id binary(20) DEFAULT NULL COMMENT 'action_url.id',
   notes_url_id binary(20) DEFAULT NULL COMMENT 'notes_url.id',
@@ -134,16 +134,16 @@ CREATE TABLE host_state (
   performance_data text DEFAULT NULL,
   check_commandline text DEFAULT NULL,
 
-  is_problem enum('y', 'n') NOT NULL,
-  is_handled enum('y', 'n') NOT NULL,
-  is_reachable enum('y', 'n') NOT NULL,
-  is_flapping enum('y', 'n') NOT NULL,
-  is_overdue enum('y', 'n') NOT NULL,
+  is_problem enum('n', 'y') NOT NULL,
+  is_handled enum('n', 'y') NOT NULL,
+  is_reachable enum('n', 'y') NOT NULL,
+  is_flapping enum('n', 'y') NOT NULL,
+  is_overdue enum('n', 'y') NOT NULL,
 
-  is_acknowledged enum('y', 'n', 'sticky') NOT NULL,
+  is_acknowledged enum('n', 'y', 'sticky') NOT NULL,
   acknowledgement_comment_id binary(20) DEFAULT NULL COMMENT 'comment.id',
 
-  in_downtime enum('y', 'n') NOT NULL,
+  in_downtime enum('n', 'y') NOT NULL,
 
   execution_time int unsigned DEFAULT NULL,
   latency int unsigned DEFAULT NULL,
@@ -181,21 +181,21 @@ CREATE TABLE service (
   check_interval int unsigned NOT NULL,
   check_retry_interval int unsigned NOT NULL,
 
-  active_checks_enabled enum('y','n') NOT NULL,
-  passive_checks_enabled enum('y','n') NOT NULL,
-  event_handler_enabled enum('y','n') NOT NULL,
-  notifications_enabled enum('y','n') NOT NULL,
+  active_checks_enabled enum('n', 'y') NOT NULL,
+  passive_checks_enabled enum('n', 'y') NOT NULL,
+  event_handler_enabled enum('n', 'y') NOT NULL,
+  notifications_enabled enum('n', 'y') NOT NULL,
 
-  flapping_enabled enum('y','n') NOT NULL,
+  flapping_enabled enum('n', 'y') NOT NULL,
   flapping_threshold_low float NOT NULL,
   flapping_threshold_high float NOT NULL,
 
-  perfdata_enabled enum('y','n') NOT NULL,
+  perfdata_enabled enum('n', 'y') NOT NULL,
 
   eventcommand varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'eventcommand.name',
   eventcommand_id binary(20) DEFAULT NULL COMMENT 'eventcommand.id',
 
-  is_volatile enum('y','n') NOT NULL,
+  is_volatile enum('n', 'y') NOT NULL,
 
   action_url_id binary(20) DEFAULT NULL COMMENT 'action_url.id',
   notes_url_id binary(20) DEFAULT NULL COMMENT 'notes_url.id',
@@ -284,16 +284,16 @@ CREATE TABLE service_state (
   performance_data text DEFAULT NULL,
   check_commandline text DEFAULT NULL,
 
-  is_problem enum('y', 'n') NOT NULL,
-  is_handled enum('y', 'n') NOT NULL,
-  is_reachable enum('y', 'n') NOT NULL,
-  is_flapping enum('y', 'n') NOT NULL,
-  is_overdue enum('y', 'n') NOT NULL,
+  is_problem enum('n', 'y') NOT NULL,
+  is_handled enum('n', 'y') NOT NULL,
+  is_reachable enum('n', 'y') NOT NULL,
+  is_flapping enum('n', 'y') NOT NULL,
+  is_overdue enum('n', 'y') NOT NULL,
 
-  is_acknowledged enum('y', 'n', 'sticky') NOT NULL,
+  is_acknowledged enum('n', 'y', 'sticky') NOT NULL,
   acknowledgement_comment_id binary(20) DEFAULT NULL COMMENT 'comment.id',
 
-  in_downtime enum('y', 'n') NOT NULL,
+  in_downtime enum('n', 'y') NOT NULL,
 
   execution_time int unsigned DEFAULT NULL,
   latency int unsigned DEFAULT NULL,
@@ -334,16 +334,16 @@ CREATE TABLE icingadb_instance (
   environment_id binary(20) NOT NULL COMMENT 'environment.id',
   endpoint_id binary(20) DEFAULT NULL COMMENT 'endpoint.id',
   heartbeat bigint unsigned NOT NULL COMMENT '*nix timestamp',
-  responsible enum('y','n') NOT NULL,
+  responsible enum('n', 'y') NOT NULL,
 
   icinga2_version varchar(255) NOT NULL,
   icinga2_start_time bigint unsigned NOT NULL,
-  icinga2_notifications_enabled enum('y','n') NOT NULL,
-  icinga2_active_service_checks_enabled enum('y','n') NOT NULL,
-  icinga2_active_host_checks_enabled enum('y','n') NOT NULL,
-  icinga2_event_handlers_enabled enum('y','n') NOT NULL,
-  icinga2_flap_detection_enabled enum('y','n') NOT NULL,
-  icinga2_performance_data_enabled enum('y','n') NOT NULL,
+  icinga2_notifications_enabled enum('n', 'y') NOT NULL,
+  icinga2_active_service_checks_enabled enum('n', 'y') NOT NULL,
+  icinga2_active_host_checks_enabled enum('n', 'y') NOT NULL,
+  icinga2_event_handlers_enabled enum('n', 'y') NOT NULL,
+  icinga2_flap_detection_enabled enum('n', 'y') NOT NULL,
+  icinga2_performance_data_enabled enum('n', 'y') NOT NULL,
 
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
@@ -387,10 +387,10 @@ CREATE TABLE checkcommand_argument (
   argument_order smallint DEFAULT NULL,
   description text DEFAULT NULL,
   argument_key_override varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  repeat_key enum('y','n') NOT NULL,
-  required enum('y','n') NOT NULL,
+  repeat_key enum('n', 'y') NOT NULL,
+  required enum('n', 'y') NOT NULL,
   set_if varchar(255) DEFAULT NULL,
-  skip_key enum('y','n') NOT NULL,
+  skip_key enum('n', 'y') NOT NULL,
 
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
@@ -446,10 +446,10 @@ CREATE TABLE eventcommand_argument (
   argument_order smallint DEFAULT NULL,
   description text DEFAULT NULL,
   argument_key_override varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  repeat_key enum('y','n') NOT NULL,
-  required enum('y','n') NOT NULL,
+  repeat_key enum('n', 'y') NOT NULL,
+  required enum('n', 'y') NOT NULL,
   set_if varchar(255) DEFAULT NULL,
-  skip_key enum('y','n') NOT NULL,
+  skip_key enum('n', 'y') NOT NULL,
 
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
@@ -504,10 +504,10 @@ CREATE TABLE notificationcommand_argument (
   argument_order smallint DEFAULT NULL,
   description text DEFAULT NULL,
   argument_key_override varchar(64) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
-  repeat_key enum('y','n') NOT NULL,
-  required enum('y','n') NOT NULL,
+  repeat_key enum('n', 'y') NOT NULL,
+  required enum('n', 'y') NOT NULL,
   set_if varchar(255) DEFAULT NULL,
-  skip_key enum('y','n') NOT NULL,
+  skip_key enum('n', 'y') NOT NULL,
 
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
@@ -550,8 +550,8 @@ CREATE TABLE comment (
   text text NOT NULL,
   entry_type enum('comment','ack') NOT NULL,
   entry_time bigint unsigned NOT NULL,
-  is_persistent enum('y','n') NOT NULL,
-  is_sticky enum('y','n') NOT NULL,
+  is_persistent enum('n', 'y') NOT NULL,
+  is_sticky enum('n', 'y') NOT NULL,
   expire_time bigint unsigned DEFAULT NULL,
 
   zone_id binary(20) DEFAULT NULL COMMENT 'zone.id',
@@ -581,9 +581,9 @@ CREATE TABLE downtime (
   scheduled_start_time bigint unsigned NOT NULL,
   scheduled_end_time bigint unsigned NOT NULL,
   flexible_duration bigint unsigned NOT NULL,
-  is_flexible enum('y', 'n') NOT NULL,
+  is_flexible enum('n', 'y') NOT NULL,
 
-  is_in_effect enum('y', 'n') NOT NULL,
+  is_in_effect enum('n', 'y') NOT NULL,
   start_time bigint unsigned DEFAULT NULL COMMENT 'Time when the host went into a problem state during the downtimes timeframe',
   end_time bigint unsigned DEFAULT NULL COMMENT 'Problem state assumed: scheduled_end_time if fixed, start_time + flexible_duration otherwise',
 
@@ -709,7 +709,7 @@ CREATE TABLE timeperiod (
   name varchar(255) NOT NULL,
   name_ci varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   display_name varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
-  prefer_includes enum('y','n') NOT NULL,
+  prefer_includes enum('n', 'y') NOT NULL,
 
   zone_id binary(20) DEFAULT NULL COMMENT 'zone.id',
 
@@ -792,7 +792,7 @@ CREATE TABLE user (
   email varchar(255) NOT NULL,
   pager varchar(255) NOT NULL,
 
-  notifications_enabled enum('y', 'n') NOT NULL,
+  notifications_enabled enum('n', 'y') NOT NULL,
 
   timeperiod_id binary(20) DEFAULT NULL COMMENT 'timeperiod.id',
 
@@ -866,7 +866,7 @@ CREATE TABLE zone (
   name varchar(255) NOT NULL,
   name_ci varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
 
-  is_global enum('y','n') NOT NULL,
+  is_global enum('n', 'y') NOT NULL,
   parent_id binary(20) DEFAULT NULL COMMENT 'zone.id',
 
   depth tinyint unsigned NOT NULL,
@@ -943,13 +943,13 @@ CREATE TABLE downtime_history (
   author varchar(255) NOT NULL COLLATE utf8mb4_unicode_ci,
   cancelled_by varchar(255) DEFAULT NULL COLLATE utf8mb4_unicode_ci,
   comment text NOT NULL,
-  is_flexible enum('y', 'n') NOT NULL,
+  is_flexible enum('n', 'y') NOT NULL,
   flexible_duration bigint unsigned NOT NULL,
   scheduled_start_time bigint unsigned NOT NULL,
   scheduled_end_time bigint unsigned NOT NULL,
   start_time bigint unsigned NOT NULL COMMENT 'Time when the host went into a problem state during the downtimes timeframe',
   end_time bigint unsigned NOT NULL COMMENT 'Problem state assumed: scheduled_end_time if fixed, start_time + duration otherwise',
-  has_been_cancelled enum('y', 'n') NOT NULL,
+  has_been_cancelled enum('n', 'y') NOT NULL,
   trigger_time bigint unsigned NOT NULL,
   cancel_time bigint unsigned DEFAULT NULL,
 
@@ -969,11 +969,11 @@ CREATE TABLE comment_history (
   removed_by varchar(255) DEFAULT NULL COLLATE utf8mb4_unicode_ci,
   comment text NOT NULL,
   entry_type enum('comment','ack') NOT NULL,
-  is_persistent enum('y','n') NOT NULL,
-  is_sticky enum('y','n') NOT NULL,
+  is_persistent enum('n', 'y') NOT NULL,
+  is_sticky enum('n', 'y') NOT NULL,
   expire_time bigint unsigned DEFAULT NULL,
   remove_time bigint unsigned DEFAULT NULL,
-  has_been_removed enum('y','n') NOT NULL,
+  has_been_removed enum('n', 'y') NOT NULL,
 
   PRIMARY KEY (comment_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
@@ -1010,8 +1010,8 @@ CREATE TABLE acknowledgement_history (
   cleared_by varchar(255) DEFAULT NULL COLLATE utf8mb4_unicode_ci,
   comment text DEFAULT NULL,
   expire_time bigint unsigned DEFAULT NULL,
-  is_sticky enum('y','n') NOT NULL,
-  is_persistent enum('y','n') NOT NULL,
+  is_sticky enum('n', 'y') NOT NULL,
+  is_persistent enum('n', 'y') NOT NULL,
 
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;

--- a/schema/mysql/upgrades/1.0.0-rc2.sql
+++ b/schema/mysql/upgrades/1.0.0-rc2.sql
@@ -31,5 +31,80 @@ ALTER TABLE usergroup ADD INDEX `idx_usergroup_display_name` (`display_name`) CO
 ALTER TABLE usergroup ADD INDEX idx_usergroup_name_ci (name_ci) COMMENT 'Usergroup list filtered using quick search';
 ALTER TABLE usergroup ADD INDEX idx_usergroup_name (name) COMMENT 'Usergroup list filtered/ordered by name; Usergroup detail filter';
 
+ALTER TABLE host
+    MODIFY active_checks_enabled enum('n','y') NOT NULL,
+    MODIFY passive_checks_enabled enum('n','y') NOT NULL,
+    MODIFY event_handler_enabled enum('n','y') NOT NULL,
+    MODIFY notifications_enabled enum('n','y') NOT NULL,
+    MODIFY flapping_enabled enum('n','y') NOT NULL,
+    MODIFY perfdata_enabled enum('n','y') NOT NULL,
+    MODIFY is_volatile enum('n','y') NOT NULL;
+ALTER TABLE host_state
+    MODIFY is_problem enum('n','y') NOT NULL,
+    MODIFY is_handled enum('n','y') NOT NULL,
+    MODIFY is_reachable enum('n','y') NOT NULL,
+    MODIFY is_flapping enum('n','y') NOT NULL,
+    MODIFY is_overdue enum('n','y') NOT NULL,
+    MODIFY is_acknowledged enum('n','y','sticky') NOT NULL,
+    MODIFY in_downtime enum('n','y') NOT NULL;
+ALTER TABLE service
+    MODIFY active_checks_enabled enum('n','y') NOT NULL,
+    MODIFY passive_checks_enabled enum('n','y') NOT NULL,
+    MODIFY event_handler_enabled enum('n','y') NOT NULL,
+    MODIFY notifications_enabled enum('n','y') NOT NULL,
+    MODIFY flapping_enabled enum('n','y') NOT NULL,
+    MODIFY perfdata_enabled enum('n','y') NOT NULL,
+    MODIFY is_volatile enum('n','y') NOT NULL;
+ALTER TABLE service_state
+    MODIFY is_problem enum('n','y') NOT NULL,
+    MODIFY is_handled enum('n','y') NOT NULL,
+    MODIFY is_reachable enum('n','y') NOT NULL,
+    MODIFY is_flapping enum('n','y') NOT NULL,
+    MODIFY is_overdue enum('n','y') NOT NULL,
+    MODIFY is_acknowledged enum('n','y','sticky') NOT NULL,
+    MODIFY in_downtime enum('n','y') NOT NULL;
+ALTER TABLE icingadb_instance
+    MODIFY responsible enum('n','y') NOT NULL,
+    MODIFY icinga2_notifications_enabled enum('n','y') NOT NULL,
+    MODIFY icinga2_active_service_checks_enabled enum('n','y') NOT NULL,
+    MODIFY icinga2_active_host_checks_enabled enum('n','y') NOT NULL,
+    MODIFY icinga2_event_handlers_enabled enum('n','y') NOT NULL,
+    MODIFY icinga2_flap_detection_enabled enum('n','y') NOT NULL,
+    MODIFY icinga2_performance_data_enabled enum('n','y') NOT NULL;
+ALTER TABLE checkcommand_argument
+    MODIFY repeat_key enum('n','y') NOT NULL,
+    MODIFY required enum('n','y') NOT NULL,
+    MODIFY skip_key enum('n','y') NOT NULL;
+ALTER TABLE eventcommand_argument
+    MODIFY repeat_key enum('n','y') NOT NULL,
+    MODIFY required enum('n','y') NOT NULL,
+    MODIFY skip_key enum('n','y') NOT NULL;
+ALTER TABLE notificationcommand_argument
+    MODIFY repeat_key enum('n','y') NOT NULL,
+    MODIFY required enum('n','y') NOT NULL,
+    MODIFY skip_key enum('n','y') NOT NULL;
+ALTER TABLE comment
+    MODIFY is_persistent enum('n','y') NOT NULL,
+    MODIFY is_sticky enum('n','y') NOT NULL;
+ALTER TABLE downtime
+    MODIFY is_flexible enum('n','y') NOT NULL,
+    MODIFY is_in_effect enum('n','y') NOT NULL;
+ALTER TABLE timeperiod
+    MODIFY prefer_includes enum('n','y') NOT NULL;
+ALTER TABLE user
+    MODIFY notifications_enabled enum('n','y') NOT NULL;
+ALTER TABLE zone
+    MODIFY is_global enum('n','y') NOT NULL;
+ALTER TABLE downtime_history
+    MODIFY is_flexible enum('n','y') NOT NULL,
+    MODIFY has_been_cancelled enum('n','y') NOT NULL;
+ALTER TABLE comment_history
+    MODIFY is_persistent enum('n','y') NOT NULL,
+    MODIFY is_sticky enum('n','y') NOT NULL,
+    MODIFY has_been_removed enum('n','y') NOT NULL;
+ALTER TABLE acknowledgement_history
+    MODIFY is_sticky enum('n','y') NOT NULL,
+    MODIFY is_persistent enum('n','y') NOT NULL;
+
 INSERT INTO icingadb_schema (version, timestamp)
   VALUES (2, CURRENT_TIMESTAMP() * 1000);


### PR DESCRIPTION
This ensures that 'n' < 'y' when sorting, as you'd expect when either comparing the alphabetical order of both values or the corresponding 0/1 values for a boolean.

fixes #234