### PR TITLE
Integrate 1.0.0-rc2 schema

### DIFF
--- a/schema/1.0.0-rc2.sql
+++ b/schema/1.0.0-rc2.sql
@@ -30,3 +30,6 @@ ALTER TABLE user ADD INDEX idx_user_name (name) COMMENT 'User list filtered/orde
 ALTER TABLE usergroup ADD INDEX `idx_usergroup_display_name` (`display_name`) COMMENT 'Usergroup list filtered/ordered by display_name';
 ALTER TABLE usergroup ADD INDEX idx_usergroup_name_ci (name_ci) COMMENT 'Usergroup list filtered using quick search';
 ALTER TABLE usergroup ADD INDEX idx_usergroup_name (name) COMMENT 'Usergroup list filtered/ordered by name; Usergroup detail filter';
+
+INSERT INTO icingadb_schema (version, timestamp)
+  VALUES (2, CURRENT_TIMESTAMP() * 1000);

--- a/schema/1.0.0-rc2.sql
+++ b/schema/1.0.0-rc2.sql
@@ -1,15 +1,32 @@
 ALTER TABLE host_state DROP PRIMARY KEY;
-ALTER TABLE host_state ADD COLUMN id binary(20) NOT NULL FIRST;
+ALTER TABLE host_state ADD COLUMN id binary(20) NOT NULL COMMENT 'host.id' FIRST;
 UPDATE host_state SET id = host_id;
 ALTER TABLE host_state ADD PRIMARY KEY (id);
 ALTER TABLE host_state ADD COLUMN properties_checksum binary(20) AFTER environment_id;
 UPDATE host_state SET properties_checksum = 0;
-ALTER TABLE host_state MODIFY COLUMN properties_checksum binary(20) NOT NULL;
+ALTER TABLE host_state MODIFY COLUMN properties_checksum binary(20) COMMENT 'sha1(all properties)' NOT NULL;
 
 ALTER TABLE service_state DROP PRIMARY KEY;
-ALTER TABLE service_state ADD COLUMN id binary(20) NOT NULL FIRST;
+ALTER TABLE service_state ADD COLUMN id binary(20) NOT NULL COMMENT 'service.id' FIRST;
 UPDATE service_state SET id = service_id;
 ALTER TABLE service_state ADD PRIMARY KEY (id);
 ALTER TABLE service_state ADD COLUMN properties_checksum binary(20) AFTER environment_id;
 UPDATE service_state SET properties_checksum = 0;
-ALTER TABLE service_state MODIFY COLUMN properties_checksum binary(20) NOT NULL;
+ALTER TABLE service_state MODIFY COLUMN properties_checksum binary(20) COMMENT 'sha1(all properties)' NOT NULL;
+
+ALTER TABLE checkcommand_argument MODIFY COLUMN argument_order smallint DEFAULT NULL;
+ALTER TABLE eventcommand_argument MODIFY COLUMN argument_order smallint DEFAULT NULL;
+ALTER TABLE notificationcommand_argument MODIFY COLUMN argument_order smallint DEFAULT NULL;
+
+ALTER TABLE acknowledgement_history MODIFY COLUMN id binary(20) NOT NULL COMMENT 'sha1(environment.name + "Host"|"Service" + host|service.name + set_time)';
+ALTER TABLE flapping_history MODIFY COLUMN id binary(20) NOT NULL COMMENT 'sha1(environment.name + "Host"|"Service" + host|service.name + start_time)';
+
+ALTER TABLE host ADD INDEX idx_host_name_ci (name_ci) COMMENT 'Host list filtered using quick search';
+ALTER TABLE service ADD INDEX idx_service_name_ci (name_ci) COMMENT 'Service list filtered using quick search';
+
+ALTER TABLE user ADD INDEX idx_user_name_ci (name_ci) COMMENT 'User list filtered using quick search';
+ALTER TABLE user ADD INDEX idx_user_name (name) COMMENT 'User list filtered/ordered by name; User detail filter';
+
+ALTER TABLE usergroup ADD INDEX `idx_usergroup_display_name` (`display_name`) COMMENT 'Usergroup list filtered/ordered by display_name';
+ALTER TABLE usergroup ADD INDEX idx_usergroup_name_ci (name_ci) COMMENT 'Usergroup list filtered using quick search';
+ALTER TABLE usergroup ADD INDEX idx_usergroup_name (name) COMMENT 'Usergroup list filtered/ordered by name; Usergroup detail filter';

--- a/schema/mysql.schema.sql
+++ b/schema/mysql.schema.sql
@@ -117,8 +117,10 @@ CREATE TABLE hostgroup_customvar (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE host_state (
+  id binary(20) NOT NULL COMMENT 'host.id',
   host_id binary(20) NOT NULL COMMENT 'host.id',
   environment_id binary(20) NOT NULL COMMENT 'sha1(environment.name)',
+  properties_checksum binary(20) NOT NULL COMMENT 'sha1(all properties)',
 
   state_type enum('hard', 'soft') NOT NULL,
   soft_state tinyint unsigned NOT NULL,
@@ -153,7 +155,7 @@ CREATE TABLE host_state (
   next_check bigint unsigned NOT NULL,
   next_update bigint unsigned NOT NULL,
 
-  PRIMARY KEY (host_id)
+  PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE service (
@@ -265,8 +267,10 @@ CREATE TABLE servicegroup_customvar (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE service_state (
+  id binary(20) NOT NULL COMMENT 'service.id',
   service_id binary(20) NOT NULL COMMENT 'service.id',
   environment_id binary(20) NOT NULL COMMENT 'sha1(environment.name)',
+  properties_checksum binary(20) NOT NULL COMMENT 'sha1(all properties)',
 
   state_type enum('hard', 'soft') NOT NULL,
   soft_state tinyint unsigned NOT NULL,
@@ -301,7 +305,7 @@ CREATE TABLE service_state (
   next_check bigint unsigned NOT NULL,
   next_update bigint unsigned NOT NULL,
 
-  PRIMARY KEY (service_id)
+  PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE endpoint (

--- a/schema/mysql.schema.sql
+++ b/schema/mysql.schema.sql
@@ -357,7 +357,7 @@ CREATE TABLE icingadb_schema (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 INSERT INTO icingadb_schema (version, timestamp)
-  VALUES (1, CURRENT_TIMESTAMP() * 1000);
+  VALUES (2, CURRENT_TIMESTAMP() * 1000);
 
 CREATE TABLE checkcommand (
   id binary(20) NOT NULL COMMENT 'sha1(environment.name + type + name)',


### PR DESCRIPTION
This PR
* applies all changes from the existing `1.0.0-rc2.sql` file to the `mysql.schema.sql` file so that it represents the current version of the schema
* adds all changes done to `mysql.schema.sql` since the `v1.0.0-rc1` git tag to the `1.0.0-rc2.sql` file
* inserts schema version 2 into the `icingadb_schema` table

The diff between applying the initial schema and applying the rc1 schema and then the upgrade file now looks as follows:

```
$ docker run --rm -p 127.30.177.65:3306:3306 -it -e MYSQL_ROOT_PASSWORD=root mariadb:latest &
$ mysql -h127.30.177.65 -uroot -proot -e 'CREATE DATABASE a; CREATE DATABASE b;'
$ mysql -h127.30.177.65 -uroot -proot a < schema/mysql.schema.sql
$ cat <(git show v1.0.0-rc1:etc/schema/mysql/mysql.schema.sql) schema/1.0.0-rc2.sql | mysql -h127.30.177.65 -uroot -proot b
$ diff -u <(mysqldump -h127.30.177.65 -uroot -proot a) <(mysqldump -h127.30.177.65 -uroot -proot b)
```

```diff
--- /proc/self/fd/11	2021-05-28 17:13:59.670143828 +0200
+++ /proc/self/fd/12	2021-05-28 17:13:59.670143828 +0200
@@ -1,6 +1,6 @@
 -- MariaDB dump 10.19  Distrib 10.5.10-MariaDB, for Linux (x86_64)
 --
--- Host: 127.30.177.65    Database: a
+-- Host: 127.30.177.65    Database: b
 -- ------------------------------------------------------
 -- Server version	10.5.6-MariaDB-1:10.5.6+maria~focal
 
@@ -699,8 +699,8 @@
   KEY `idx_notes_url_checksum` (`notes_url_id`) COMMENT 'cleanup',
   KEY `idx_icon_image_checksum` (`icon_image_id`) COMMENT 'cleanup',
   KEY `idx_host_display_name` (`display_name`) COMMENT 'Host list filtered/ordered by display_name',
-  KEY `idx_host_name_ci` (`name_ci`) COMMENT 'Host list filtered using quick search',
-  KEY `idx_host_name` (`name`) COMMENT 'Host list filtered/ordered by name; Host detail filter'
+  KEY `idx_host_name` (`name`) COMMENT 'Host list filtered/ordered by name; Host detail filter',
+  KEY `idx_host_name_ci` (`name_ci`) COMMENT 'Host list filtered using quick search'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -918,7 +918,7 @@
   `version` smallint(5) unsigned NOT NULL,
   `timestamp` bigint(20) unsigned NOT NULL,
   PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
+) ENGINE=InnoDB AUTO_INCREMENT=3 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -927,7 +927,7 @@
 
 LOCK TABLES `icingadb_schema` WRITE;
 /*!40000 ALTER TABLE `icingadb_schema` DISABLE KEYS */;
-INSERT INTO `icingadb_schema` VALUES (1,2,20210528151342000);
+INSERT INTO `icingadb_schema` VALUES (1,1,20210528151353000),(2,2,20210528151354000);
 /*!40000 ALTER TABLE `icingadb_schema` ENABLE KEYS */;
 UNLOCK TABLES;
 
@@ -1328,8 +1328,8 @@
   PRIMARY KEY (`id`),
   KEY `idx_service_display_name` (`display_name`) COMMENT 'Service list filtered/ordered by display_name',
   KEY `idx_service_host_id` (`host_id`,`display_name`) COMMENT 'Service list filtered by host and ordered by display_name',
-  KEY `idx_service_name_ci` (`name_ci`) COMMENT 'Service list filtered using quick search',
-  KEY `idx_service_name` (`name`) COMMENT 'Service list filtered/ordered by name; Service detail filter'
+  KEY `idx_service_name` (`name`) COMMENT 'Service list filtered/ordered by name; Service detail filter',
+  KEY `idx_service_name_ci` (`name_ci`) COMMENT 'Service list filtered using quick search'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
```

So the difference is the content of the `icingadb_schema` table (as expected) and the order of some indices.