### PR TITLE
Add issue template for bug reports

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,37 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+## Describe the bug
+
+A clear and concise description of what the bug is.
+
+## To Reproduce
+
+Provide a link to a live example, or an unambiguous set of steps to reproduce this bug. Include configuration, logs, etc. to reproduce, if relevant.
+
+1.
+2.
+3.
+4.
+
+## Expected behavior
+
+A clear and concise description of what you expected to happen.
+
+## Your Environment
+
+Include as many relevant details about the environment you experienced the problem in
+
+* Icinga DB version:
+* Icinga 2 version:
+* Operating System and version:
+
+## Additional context
+
+Add any other context about the problem here.


### PR DESCRIPTION
Add an issue template to have another big button for bug reports on https://github.com/Icinga/icingadb/issues/new/choose

Based on the Icinga 2 issue template. I omitted feature requests for now, I think we should get to 1.0 first before we think of additional feature requests.