### PR TITLE
Add custom vars to the runtime update sync

### DIFF
--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -214,7 +214,9 @@ func run() int {
 
 							logger.Infof("Starting runtime updates sync")
 
-							return rt.Sync(synctx, v1.Factories, lastRuntimeStreamId)
+							// @TODO(el): The customvar runtime update sync may change because the customvar flat
+							// runtime update sync is not yet implemented.
+							return rt.Sync(synctx, append(v1.Factories, v1.NewCustomvar), lastRuntimeStreamId)
 						})
 
 						if err := g.Wait(); err != nil && !utils.IsContextCanceled(err) {


### PR DESCRIPTION
The customvar runtime update sync may change because the customvar
flat runtime update sync is not yet implemented.