### PR TITLE
HA: context used to start transaction must not be canceled before the transaction is committed

### DIFF
--- a/pkg/icingadb/ha.go
+++ b/pkg/icingadb/ha.go
@@ -233,14 +233,15 @@ func (h *HA) realize(s *icingaredisv1.IcingaStatus, t *types.UnixMilli, shouldLo
 			}
 		}
 
-		cancel()
-
 		if err := tx.Commit(); err != nil {
+			cancel()
 			return err
 		}
 		if takeover {
 			h.signalTakeover()
 		}
+
+		cancel()
 		break
 	}
 


### PR DESCRIPTION
This was introduced by 621c1b953737a8983ba9701da8f01fc5426000c3 and leads to `tx.Commit()` always returning an "context canceled" error.