### PR TITLE
schema: Re-add indices for `host_id` and `service_id` in state tables

### DIFF
--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -155,7 +155,8 @@ CREATE TABLE host_state (
   next_check bigint unsigned NOT NULL,
   next_update bigint unsigned NOT NULL,
 
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+  UNIQUE INDEX idx_host_state_host_id (host_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE service (
@@ -305,7 +306,8 @@ CREATE TABLE service_state (
   next_check bigint unsigned NOT NULL,
   next_update bigint unsigned NOT NULL,
 
-  PRIMARY KEY (id)
+  PRIMARY KEY (id),
+  UNIQUE INDEX idx_service_state_service_id (service_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE endpoint (

--- a/schema/mysql/upgrades/1.0.0-rc2.sql
+++ b/schema/mysql/upgrades/1.0.0-rc2.sql
@@ -5,6 +5,7 @@ ALTER TABLE host_state ADD PRIMARY KEY (id);
 ALTER TABLE host_state ADD COLUMN properties_checksum binary(20) AFTER environment_id;
 UPDATE host_state SET properties_checksum = 0;
 ALTER TABLE host_state MODIFY COLUMN properties_checksum binary(20) COMMENT 'sha1(all properties)' NOT NULL;
+ALTER TABLE host_state ADD UNIQUE INDEX idx_host_state_host_id (host_id);
 
 ALTER TABLE service_state DROP PRIMARY KEY;
 ALTER TABLE service_state ADD COLUMN id binary(20) NOT NULL COMMENT 'service.id' FIRST;
@@ -13,6 +14,7 @@ ALTER TABLE service_state ADD PRIMARY KEY (id);
 ALTER TABLE service_state ADD COLUMN properties_checksum binary(20) AFTER environment_id;
 UPDATE service_state SET properties_checksum = 0;
 ALTER TABLE service_state MODIFY COLUMN properties_checksum binary(20) COMMENT 'sha1(all properties)' NOT NULL;
+ALTER TABLE service_state ADD UNIQUE INDEX idx_service_state_service_id (service_id);
 
 ALTER TABLE checkcommand_argument MODIFY COLUMN argument_order smallint DEFAULT NULL;
 ALTER TABLE eventcommand_argument MODIFY COLUMN argument_order smallint DEFAULT NULL;


### PR DESCRIPTION
#281 changed the pk in tables `host_state` and `service_state` to column `id`. This means that there is no index anymore on `host_id` and `service_id` on which Icinga DB Web heavily relies upon. The result was a full table scan for joins to these tables and heavily degraded performance.

This re-adds those indices.