### PR TITLE
Sync customvar flat runtime updates

### DIFF
--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -199,7 +199,11 @@ func run() int {
 						g.Go(func() error {
 							defer configInitSync.Done()
 
-							<-dump.Done("icinga:customvar")
+							select {
+							case <-dump.Done("icinga:customvar"):
+							case <-synctx.Done():
+								return synctx.Err()
+							}
 
 							logger.Info("Syncing customvar")
 							logger.Info("Syncing customvar_flat")

--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -6,7 +6,6 @@ import (
 	"github.com/icinga/icingadb/internal/command"
 	"github.com/icinga/icingadb/pkg/com"
 	"github.com/icinga/icingadb/pkg/common"
-	"github.com/icinga/icingadb/pkg/contracts"
 	"github.com/icinga/icingadb/pkg/icingadb"
 	"github.com/icinga/icingadb/pkg/icingadb/history"
 	"github.com/icinga/icingadb/pkg/icingadb/overdue"
@@ -237,13 +236,7 @@ func run() int {
 							configInitSync.Wait()
 							logger.Info("Starting config runtime updates sync")
 
-							// @TODO(el): The customvar runtime update sync may change because the customvar flat
-							// runtime update sync is not yet implemented.
-							return rt.Sync(
-								synctx,
-								append([]contracts.EntityFactoryFunc{v1.NewCustomvar}, v1.ConfigFactories...),
-								runtimeConfigUpdateStreams,
-							)
+							return rt.Sync(synctx, v1.ConfigFactories, runtimeConfigUpdateStreams)
 						})
 
 						g.Go(func() error {

--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -181,7 +181,7 @@ func run() int {
 							g.Go(func() error {
 								defer configInitSync.Done()
 
-								return s.SyncAfterDump(synctx, common.NewSyncSubject(factory.WithInit), dump)
+								return s.SyncAfterDump(synctx, common.NewSyncSubject(factory), dump)
 							})
 						}
 
@@ -192,7 +192,7 @@ func run() int {
 							g.Go(func() error {
 								defer stateInitSync.Done()
 
-								return s.SyncAfterDump(synctx, common.NewSyncSubject(factory.WithInit), dump)
+								return s.SyncAfterDump(synctx, common.NewSyncSubject(factory), dump)
 							})
 						}
 

--- a/pkg/common/sync_subject.go
+++ b/pkg/common/sync_subject.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"github.com/icinga/icingadb/pkg/contracts"
+	"github.com/icinga/icingadb/pkg/utils"
 )
 
 // SyncSubject defines information about entities to be synchronized.
@@ -31,6 +32,11 @@ func (s SyncSubject) Entity() contracts.Entity {
 // Factory returns the entity factory function.
 func (s SyncSubject) Factory() contracts.EntityFactoryFunc {
 	return s.factory
+}
+
+// Name returns the declared name of the entity.
+func (s SyncSubject) Name() string {
+	return utils.Name(s.entity)
 }
 
 // WithChecksum returns whether entities from the factory implement contracts.Checksumer.

--- a/pkg/contracts/contracts.go
+++ b/pkg/contracts/contracts.go
@@ -49,17 +49,6 @@ type Checksumer interface {
 // EntityFactoryFunc knows how to create an Entity.
 type EntityFactoryFunc func() Entity
 
-// WithInit calls Init() on the created Entity if applicable.
-func (f EntityFactoryFunc) WithInit() Entity {
-	e := f()
-
-	if initer, ok := e.(Initer); ok {
-		initer.Init()
-	}
-
-	return e
-}
-
 // Waiter implements the Wait method,
 // which blocks until execution is complete.
 type Waiter interface {

--- a/pkg/icingadb/db.go
+++ b/pkg/icingadb/db.go
@@ -438,7 +438,7 @@ func (db *DB) CreateStreamed(ctx context.Context, entities <-chan contracts.Enti
 		return errors.Wrap(err, "can't copy first entity")
 	}
 
-	sem := db.getSemaphoreForTable(utils.TableName(first))
+	sem := db.GetSemaphoreForTable(utils.TableName(first))
 	stmt, placeholders := db.BuildInsertStmt(first)
 
 	return db.NamedBulkExec(ctx, stmt, db.BatchSizeByPlaceholders(placeholders), sem, forward, nil)
@@ -454,7 +454,7 @@ func (db *DB) UpsertStreamed(ctx context.Context, entities <-chan contracts.Enti
 		return errors.Wrap(err, "can't copy first entity")
 	}
 
-	sem := db.getSemaphoreForTable(utils.TableName(first))
+	sem := db.GetSemaphoreForTable(utils.TableName(first))
 	stmt, placeholders := db.BuildUpsertStmt(first)
 
 	return db.NamedBulkExec(ctx, stmt, db.BatchSizeByPlaceholders(placeholders), sem, forward, succeeded)
@@ -469,7 +469,7 @@ func (db *DB) UpdateStreamed(ctx context.Context, entities <-chan contracts.Enti
 	if first == nil {
 		return errors.Wrap(err, "can't copy first entity")
 	}
-	sem := db.getSemaphoreForTable(utils.TableName(first))
+	sem := db.GetSemaphoreForTable(utils.TableName(first))
 	stmt, _ := db.BuildUpdateStmt(first)
 
 	return db.NamedBulkExecTx(ctx, stmt, db.Options.MaxRowsPerTransaction, sem, forward)
@@ -480,7 +480,7 @@ func (db *DB) UpdateStreamed(ctx context.Context, entities <-chan contracts.Enti
 // Bulk size is controlled via Options.MaxPlaceholdersPerStatement and
 // concurrency is controlled via Options.MaxConnectionsPerTable.
 func (db *DB) DeleteStreamed(ctx context.Context, entityType contracts.Entity, ids <-chan interface{}) error {
-	sem := db.getSemaphoreForTable(utils.TableName(entityType))
+	sem := db.GetSemaphoreForTable(utils.TableName(entityType))
 	return db.BulkExec(ctx, db.BuildDeleteStmt(entityType), db.Options.MaxPlaceholdersPerStatement, sem, ids)
 }
 
@@ -496,7 +496,7 @@ func (db *DB) Delete(ctx context.Context, entityType contracts.Entity, ids []int
 	return db.DeleteStreamed(ctx, entityType, idsCh)
 }
 
-func (db *DB) getSemaphoreForTable(table string) *semaphore.Weighted {
+func (db *DB) GetSemaphoreForTable(table string) *semaphore.Weighted {
 	db.tableSemaphoresMu.Lock()
 	defer db.tableSemaphoresMu.Unlock()
 

--- a/pkg/icingadb/runtime_updates.go
+++ b/pkg/icingadb/runtime_updates.go
@@ -61,7 +61,7 @@ func (r *RuntimeUpdates) Sync(ctx context.Context, factoryFuncs []contracts.Enti
 	updateMessagesByKey := make(map[string]chan<- redis.XMessage)
 
 	for _, factoryFunc := range factoryFuncs {
-		s := common.NewSyncSubject(factoryFunc.WithInit)
+		s := common.NewSyncSubject(factoryFunc)
 
 		updateMessages := make(chan redis.XMessage, bulkSize)
 		upsertEntities := make(chan contracts.Entity, bulkSize)

--- a/pkg/icingadb/v1/customvar.go
+++ b/pkg/icingadb/v1/customvar.go
@@ -44,7 +44,7 @@ func FlattenCustomvars(ctx context.Context, cvs <-chan contracts.Entity) (<-chan
 	g.Go(func() error {
 		defer close(cvFlats)
 
-		g, _ := errgroup.WithContext(ctx)
+		g, ctx := errgroup.WithContext(ctx)
 
 		for i := 0; i < runtime.NumCPU(); i++ {
 			g.Go(func() error {

--- a/tests/object_sync_test.go
+++ b/tests/object_sync_test.go
@@ -300,7 +300,6 @@ func TestObjectSync(t *testing.T) {
 						})
 
 						t.Run("CustomVarFlat", func(t *testing.T) {
-							t.Skip("runtime updates for customvar_flat are not yet implemented") // TODO(jb)
 							logger := it.Logger(t)
 							eventually.Assert(t, func(t require.TestingT) {
 								service.Vars.VerifyCustomVarFlat(t, logger, db, service)
@@ -360,9 +359,6 @@ func TestObjectSync(t *testing.T) {
 							})
 
 							t.Run("CustomVarFlat", func(t *testing.T) {
-								// TODO(jb): needs PR #297
-								t.Skip("runtime updates for customvar_flat are not yet implemented")
-
 								logger := it.Logger(t)
 								eventually.Assert(t, func(t require.TestingT) {
 									service.Vars.VerifyCustomVarFlat(t, logger, db, service)


### PR DESCRIPTION
This PR implements custom var flat handling in runtime updates. Custom vars must also be handled explicitly for this, because the original values are used to extract the flat ones.
In addition, this PR removes `contracts.EntitiyFactoryFunc.WithInit()` which checked for `contracts.Initer` every time. Now it is only done once in `common.NewSyncSubject()`.

# Test

1. Make sure there is no custom variable named `cv`:
```sql
MariaDB [icingadb]> SELECT cvflat.flatname, cvflat.flatvalue FROM customvar_flat cvflat INNER JOIN customvar cv ON cvflat.customvar_id = cv.id WHERE cv.name = "cv";
Empty set (0.002 sec)
```
2. Create a host via the Icinga API with a custom variable named `cv`:
```bash
curl -k -u user:password -H 'Accept: application/json' -X PUT 'https://localhost:5665/v1/objects/hosts/test-host' -d '{ "attrs": { "address": "127.0.0.1", "check_command": "hostalive", "vars.cv": {"key": "value", "array": ["value0", "value1"], "nested": {"key": "value", "array": ["value0", "value1"]}}}}'
```
3. Make sure the custom variable `cv` and its flat values have been synchronized:
```sql
MariaDB [icingadb]> SELECT cvflat.flatname, cvflat.flatvalue FROM customvar_flat cvflat INNER JOIN customvar cv ON cvflat.customvar_id = cv.id WHERE cv.name = "cv"\G
*************************** 1. row ***************************
 flatname: cv.nested.array[0]
flatvalue: value0
*************************** 2. row ***************************
 flatname: cv.nested.key
flatvalue: value
*************************** 3. row ***************************
 flatname: cv.key
flatvalue: value
*************************** 4. row ***************************
 flatname: cv.array[1]
flatvalue: value1
*************************** 5. row ***************************
 flatname: cv.nested.array[1]
flatvalue: value1
*************************** 6. row ***************************
 flatname: cv.array[0]
flatvalue: value0
6 rows in set (0.001 sec)
```