### PR TITLE
Downtime: Add parent_id

### DIFF
--- a/pkg/icingadb/v1/downtime.go
+++ b/pkg/icingadb/v1/downtime.go
@@ -10,6 +10,7 @@ type Downtime struct {
 	EnvironmentMeta    `json:",inline"`
 	NameMeta           `json:",inline"`
 	TriggeredById      types.Binary    `json:"triggered_by_id"`
+	ParentId           types.Binary    `json:"parent_id"`
 	ObjectType         string          `json:"object_type"`
 	HostId             types.Binary    `json:"host_id"`
 	ServiceId          types.Binary    `json:"service_id"`

--- a/pkg/icingadb/v1/history/downtime.go
+++ b/pkg/icingadb/v1/history/downtime.go
@@ -41,6 +41,7 @@ type DowntimeHistory struct {
 	HistoryTableMeta        `json:",inline"`
 	DowntimeHistoryUpserter `json:",inline"`
 	TriggeredById           types.Binary    `json:"triggered_by_id"`
+	ParentId                types.Binary    `json:"parent_id"`
 	EntryTime               types.UnixMilli `json:"entry_time"`
 	Author                  string          `json:"author"`
 	Comment                 string          `json:"comment"`

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -572,6 +572,7 @@ CREATE TABLE downtime (
   environment_id binary(20) NOT NULL COMMENT 'environment.id',
 
   triggered_by_id binary(20) DEFAULT NULL COMMENT 'downtime.id',
+  parent_id binary(20) DEFAULT NULL COMMENT 'downtime.id',
   object_type enum('host', 'service') NOT NULL,
   host_id binary(20) NOT NULL COMMENT 'host.id',
   service_id binary(20) DEFAULT NULL COMMENT 'service.id',
@@ -940,6 +941,7 @@ CREATE TABLE downtime_history (
   environment_id binary(20) NOT NULL COMMENT 'environment.id',
   endpoint_id binary(20) DEFAULT NULL COMMENT 'endpoint.id',
   triggered_by_id binary(20) DEFAULT NULL COMMENT 'downtime.id',
+  parent_id binary(20) DEFAULT NULL COMMENT 'downtime.id',
   object_type enum('host', 'service') NOT NULL,
   host_id binary(20) NOT NULL COMMENT 'host.id',
   service_id binary(20) DEFAULT NULL COMMENT 'service.id',

--- a/schema/mysql/upgrades/1.0.0-rc2.sql
+++ b/schema/mysql/upgrades/1.0.0-rc2.sql
@@ -16,6 +16,9 @@ UPDATE service_state SET properties_checksum = 0;
 ALTER TABLE service_state MODIFY COLUMN properties_checksum binary(20) COMMENT 'sha1(all properties)' NOT NULL;
 ALTER TABLE service_state ADD UNIQUE INDEX idx_service_state_service_id (service_id);
 
+ALTER TABLE downtime ADD COLUMN parent_id binary(20) AFTER triggered_by_id;
+ALTER TABLE downtime_history ADD COLUMN parent_id binary(20) AFTER triggered_by_id;
+
 ALTER TABLE checkcommand_argument MODIFY COLUMN argument_order smallint DEFAULT NULL;
 ALTER TABLE eventcommand_argument MODIFY COLUMN argument_order smallint DEFAULT NULL;
 ALTER TABLE notificationcommand_argument MODIFY COLUMN argument_order smallint DEFAULT NULL;


### PR DESCRIPTION
This PR adds the downtime attribute `parent_id` added to Icinga 2 with https://github.com/Icinga/icinga2/pull/8913 to Icinga DB.