### PR TITLE
Stream state updates from icinga:runtime:state

### DIFF
--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -94,17 +94,19 @@ func run() int {
 						// Runtime updates must wait for configuration synchronization to complete.
 						wg := sync.WaitGroup{}
 
+						// Get the last IDs of the runtime update streams before starting anything else,
+						// otherwise updates may be lost.
+						runtimeUpdateStreams, err := rt.Streams(ctx)
+						if err != nil {
+							logger.Fatalf("%+v", err)
+						}
+
 						dump := icingadb.NewDumpSignals(rc, logger)
 						g.Go(func() error {
 							logger.Info("Staring config dump signal handling")
 
 							return dump.Listen(synctx)
 						})
-
-						runtimeUpdateStreams, err := rt.Streams(ctx)
-						if err != nil {
-							logger.Fatalf("%+v", err)
-						}
 
 						g.Go(func() error {
 							select {

--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -101,7 +101,7 @@ func run() int {
 							return dump.Listen(synctx)
 						})
 
-						lastRuntimeStreamId, err := rc.StreamLastId(ctx, "icinga:runtime")
+						runtimeUpdateStreams, err := rt.Streams(ctx)
 						if err != nil {
 							logger.Fatalf("%+v", err)
 						}
@@ -209,7 +209,7 @@ func run() int {
 
 							// @TODO(el): The customvar runtime update sync may change because the customvar flat
 							// runtime update sync is not yet implemented.
-							return rt.Sync(synctx, append(v1.Factories, v1.NewCustomvar), lastRuntimeStreamId)
+							return rt.Sync(synctx, append(v1.Factories, v1.NewCustomvar), runtimeUpdateStreams)
 						})
 
 						if err := g.Wait(); err != nil && !utils.IsContextCanceled(err) {

--- a/pkg/icingaredis/utils.go
+++ b/pkg/icingaredis/utils.go
@@ -12,6 +12,25 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+// Streams represents a Redis stream key to ID mapping.
+type Streams map[string]string
+
+// Option returns the Redis stream key to ID mapping
+// as a slice of stream keys followed by their IDs
+// that is compatible for the Redis STREAMS option.
+func (s Streams) Option() []string {
+	// len*2 because we're appending the IDs later.
+	streams := make([]string, 0, len(s)*2)
+	ids := make([]string, 0, len(s))
+
+	for key, id := range s {
+		streams = append(streams, key)
+		ids = append(ids, id)
+	}
+
+	return append(streams, ids...)
+}
+
 func CreateEntities(ctx context.Context, factoryFunc contracts.EntityFactoryFunc, pairs <-chan HPair, concurrent int) (<-chan contracts.Entity, <-chan error) {
 	entities := make(chan contracts.Entity)
 	g, ctx := errgroup.WithContext(ctx)


### PR DESCRIPTION
Icinga now sends runtime updates in two separate channels,
icinga:runtime for config updates and icinga:runtime:state for
state updates. With this change, Icinga DB reads from these two
streams. This is a preparation so that state updates can be
streamed directly after a (re)start of Icinga or Icinga DB without
waiting for the config sync, as it is currently done.

refs Icinga/icinga2#8915