### PR TITLE
Insert environment

### DIFF
--- a/pkg/icingadb/db.go
+++ b/pkg/icingadb/db.go
@@ -78,6 +78,20 @@ func (db *DB) BuildInsertStmt(into interface{}) (string, int) {
 	), len(columns)
 }
 
+// BuildInsertIgnoreStmt returns an INSERT statement for the specified struct for
+// which the database ignores rows that have already been inserted.
+func (db *DB) BuildInsertIgnoreStmt(into interface{}) (string, int) {
+	columns := db.BuildColumns(into)
+
+	return fmt.Sprintf(
+		// MySQL treats UPDATE id = id as a no-op.
+		`INSERT INTO %s (%s) VALUES (%s) ON DUPLICATE KEY UPDATE id = id`,
+		utils.TableName(into),
+		strings.Join(columns, ", "),
+		fmt.Sprintf(":%s", strings.Join(columns, ", :")),
+	), len(columns)
+}
+
 func (db *DB) BuildSelectStmt(from interface{}, into interface{}) string {
 	return fmt.Sprintf(
 		`SELECT %s FROM %s`,

--- a/pkg/icingadb/ha.go
+++ b/pkg/icingadb/ha.go
@@ -242,12 +242,41 @@ func (h *HA) realize(s *icingaredisv1.IcingaStatus, t *types.UnixMilli, shouldLo
 			cancel()
 			return errors.Wrap(err, "can't commit transaction")
 		}
+
 		if takeover {
+			// Insert the environment after each heartbeat takeover if it does not already exist in the database
+			// as the environment may have changed, although this is likely to happen very rarely.
+			if err := h.insertEnvironment(s); err != nil {
+				cancel()
+				return errors.Wrap(err, "can't insert environment")
+			}
+
 			h.signalTakeover()
 		}
 
 		cancel()
 		break
+	}
+
+	return nil
+}
+
+// insertEnvironment inserts the environment from the specified state into the database if it does not already exist.
+func (h *HA) insertEnvironment(s *icingaredisv1.IcingaStatus) error {
+	e := v1.Environment{
+		EntityWithoutChecksum: v1.EntityWithoutChecksum{
+			IdMeta: v1.IdMeta{
+				Id: s.EnvironmentID(),
+			},
+		},
+		Name: s.Environment,
+	}
+
+	// Instead of checking whether the environment already exists, use an INSERT statement that does nothing if it does.
+	stmt, _ := h.db.BuildInsertIgnoreStmt(e)
+
+	if _, err := h.db.NamedExecContext(h.ctx, stmt, e); err != nil {
+		return internal.CantPerformQuery(err, stmt)
 	}
 
 	return nil

--- a/pkg/icingadb/v1/environment.go
+++ b/pkg/icingadb/v1/environment.go
@@ -1,0 +1,6 @@
+package v1
+
+type Environment struct {
+	EntityWithoutChecksum `json:",inline"`
+	Name                  string `json:"name"`
+}


### PR DESCRIPTION
With this change Icinga DB will insert the environment after each
heartbeat takeover if it does not already exist in the database as
the environment may have changed, although this is likely to happen
very rarely.

Instead of checking whether the environment already exists,
uses an INSERT statement that does nothing if it does.

fixes #292