### PR TITLE
Use SET SESSION for schema modes

### DIFF
--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -1,7 +1,7 @@
 -- IcingaDB | (c) 2019 Icinga GmbH | GPLv2+
 
-SET sql_mode = 'STRICT_ALL_TABLES,NO_ENGINE_SUBSTITUTION';
-SET innodb_strict_mode = 1;
+SET SESSION sql_mode = 'STRICT_ALL_TABLES,NO_ENGINE_SUBSTITUTION';
+SET SESSION innodb_strict_mode = 1;
 
 CREATE TABLE host (
   id binary(20) NOT NULL COMMENT 'sha1(environment.name + name)',


### PR DESCRIPTION
As of version 8, MySQL is stricter when it comes to setting system
and session variables and requires that the user importing our schema
be granted the SESSION_VARIABLES_ADMIN permission. Although the session
scope is already the default, we will now use SET SESSION for the modes
in our scheme for the sake of clarity.