### PR TITLE
Allow acknowledgement_history#{author,is_sticky,is_persistent} being NULL

### DIFF
--- a/pkg/icingadb/v1/history/ack.go
+++ b/pkg/icingadb/v1/history/ack.go
@@ -22,7 +22,7 @@ type AcknowledgementHistory struct {
 	HistoryTableMeta         `json:",inline"`
 	AckHistoryUpserter       `json:",inline"`
 	SetTime                  types.UnixMilli `json:"set_time"`
-	Author                   string          `json:"author"`
+	Author                   types.String    `json:"author"`
 	Comment                  types.String    `json:"comment"`
 	ExpireTime               types.UnixMilli `json:"expire_time"`
 	IsPersistent             types.Bool      `json:"is_persistent"`

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -1015,7 +1015,7 @@ CREATE TABLE acknowledgement_history (
   clear_time bigint unsigned DEFAULT NULL,
   author varchar(255) DEFAULT NULL COLLATE utf8mb4_unicode_ci COMMENT 'NULL if ack_set event happened before Icinga DB history recording',
   cleared_by varchar(255) DEFAULT NULL COLLATE utf8mb4_unicode_ci,
-  comment text DEFAULT NULL,
+  comment text DEFAULT NULL COMMENT 'NULL if ack_set event happened before Icinga DB history recording',
   expire_time bigint unsigned DEFAULT NULL,
   is_sticky enum('n', 'y') DEFAULT NULL COMMENT 'NULL if ack_set event happened before Icinga DB history recording',
   is_persistent enum('n', 'y') DEFAULT NULL COMMENT 'NULL if ack_set event happened before Icinga DB history recording',

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -1013,12 +1013,12 @@ CREATE TABLE acknowledgement_history (
 
   set_time bigint unsigned NOT NULL,
   clear_time bigint unsigned DEFAULT NULL,
-  author varchar(255) NOT NULL COLLATE utf8mb4_unicode_ci,
+  author varchar(255) DEFAULT NULL COLLATE utf8mb4_unicode_ci COMMENT 'NULL if ack_set event happened before Icinga DB history recording',
   cleared_by varchar(255) DEFAULT NULL COLLATE utf8mb4_unicode_ci,
   comment text DEFAULT NULL,
   expire_time bigint unsigned DEFAULT NULL,
-  is_sticky enum('n', 'y') NOT NULL,
-  is_persistent enum('n', 'y') NOT NULL,
+  is_sticky enum('n', 'y') DEFAULT NULL COMMENT 'NULL if ack_set event happened before Icinga DB history recording',
+  is_persistent enum('n', 'y') DEFAULT NULL COMMENT 'NULL if ack_set event happened before Icinga DB history recording',
 
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;

--- a/schema/mysql/upgrades/1.0.0-rc2.sql
+++ b/schema/mysql/upgrades/1.0.0-rc2.sql
@@ -110,6 +110,7 @@ ALTER TABLE comment_history
     MODIFY has_been_removed enum('n','y') NOT NULL;
 ALTER TABLE acknowledgement_history
     MODIFY author varchar(255) DEFAULT NULL COLLATE utf8mb4_unicode_ci COMMENT 'NULL if ack_set event happened before Icinga DB history recording',
+    MODIFY comment text DEFAULT NULL COMMENT 'NULL if ack_set event happened before Icinga DB history recording',
     MODIFY is_sticky enum('n','y') DEFAULT NULL COMMENT 'NULL if ack_set event happened before Icinga DB history recording',
     MODIFY is_persistent enum('n','y') DEFAULT NULL COMMENT 'NULL if ack_set event happened before Icinga DB history recording';
 

--- a/schema/mysql/upgrades/1.0.0-rc2.sql
+++ b/schema/mysql/upgrades/1.0.0-rc2.sql
@@ -109,8 +109,9 @@ ALTER TABLE comment_history
     MODIFY is_sticky enum('n','y') NOT NULL,
     MODIFY has_been_removed enum('n','y') NOT NULL;
 ALTER TABLE acknowledgement_history
-    MODIFY is_sticky enum('n','y') NOT NULL,
-    MODIFY is_persistent enum('n','y') NOT NULL;
+    MODIFY author varchar(255) DEFAULT NULL COLLATE utf8mb4_unicode_ci COMMENT 'NULL if ack_set event happened before Icinga DB history recording',
+    MODIFY is_sticky enum('n','y') DEFAULT NULL COMMENT 'NULL if ack_set event happened before Icinga DB history recording',
+    MODIFY is_persistent enum('n','y') DEFAULT NULL COMMENT 'NULL if ack_set event happened before Icinga DB history recording';
 
 INSERT INTO icingadb_schema (version, timestamp)
   VALUES (2, CURRENT_TIMESTAMP() * 1000);


### PR DESCRIPTION
... for the case an ack_set event happened before Icinga DB history recording.

fixes #305
closes #318