### PR TITLE
Make sure to set default values for config options

### DIFF
--- a/pkg/config/database.go
+++ b/pkg/config/database.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+	"github.com/creasty/defaults"
+	"github.com/icinga/icingadb/internal"
 	"github.com/icinga/icingadb/pkg/driver"
 	"github.com/icinga/icingadb/pkg/icingadb"
 	"github.com/icinga/icingadb/pkg/utils"
@@ -48,4 +50,18 @@ func (d *Database) Open(logger *zap.SugaredLogger) (*icingadb.DB, error) {
 	})
 
 	return icingadb.NewDb(db, logger, &d.Options), nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (d *Database) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	if err := defaults.Set(d); err != nil {
+		return errors.Wrap(err, "can't set default database config")
+	}
+	// Prevent recursion.
+	type self Database
+	if err := unmarshal((*self)(d)); err != nil {
+		return internal.CantUnmarshalYAML(err, d)
+	}
+
+	return nil
 }

--- a/pkg/config/redis.go
+++ b/pkg/config/redis.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"context"
+	"github.com/creasty/defaults"
 	"github.com/go-redis/redis/v8"
+	"github.com/icinga/icingadb/internal"
 	"github.com/icinga/icingadb/pkg/backoff"
 	"github.com/icinga/icingadb/pkg/icingaredis"
 	"github.com/icinga/icingadb/pkg/retry"
@@ -38,6 +40,20 @@ func (r *Redis) NewClient(logger *zap.SugaredLogger) (*icingaredis.Client, error
 	c = redis.NewClient(opts)
 
 	return icingaredis.NewClient(c, logger, &r.Options), nil
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface.
+func (r *Redis) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	if err := defaults.Set(r); err != nil {
+		return errors.Wrapf(err, "can't set defaults %#v", r)
+	}
+	// Prevent recursion.
+	type self Redis
+	if err := unmarshal((*self)(r)); err != nil {
+		return internal.CantUnmarshalYAML(err, r)
+	}
+
+	return nil
 }
 
 // dialWithLogging returns a Redis Dialer with logging capabilities.


### PR DESCRIPTION
If no option is specified in the configuration,
UnmarshalYAML is not called for the Options structs and
therefore no default values are set.

In the config structs we now check whether Options is nil,
which means that no options are set in the configuration.
Then we call unmarshal ourselves to trigger the
Options.UnmarshalYAML call to set the default values.

Alternatively, we could also call defaults.Set() here, but then,
when changing the UnmarshalYAML functions,
we would also have to check here whether changes need to be made.