### PR TITLE
Ensure extra config options are properly initialized

### DIFF
--- a/pkg/config/database.go
+++ b/pkg/config/database.go
@@ -49,3 +49,8 @@ func (d *Database) Open(logger *zap.SugaredLogger) (*icingadb.DB, error) {
 
 	return icingadb.NewDb(db, logger, &d.Options), nil
 }
+
+// Validate checks constraints in the supplied database configuration and returns an error if they are violated.
+func (d *Database) Validate() error {
+	return d.Options.Validate()
+}

--- a/pkg/config/redis.go
+++ b/pkg/config/redis.go
@@ -74,3 +74,8 @@ func dialWithLogging(logger *zap.SugaredLogger) func(context.Context, string, st
 		return
 	}
 }
+
+// Validate checks constraints in the supplied Redis configuration and returns an error if they are violated.
+func (r *Redis) Validate() error {
+	return r.Options.Validate()
+}

--- a/pkg/icingadb/db.go
+++ b/pkg/icingadb/db.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql/driver"
 	"fmt"
-	"github.com/creasty/defaults"
 	"github.com/go-sql-driver/mysql"
 	"github.com/icinga/icingadb/internal"
 	"github.com/icinga/icingadb/pkg/backoff"
@@ -56,24 +55,14 @@ type Options struct {
 	MaxRowsPerTransaction int `yaml:"MaxRowsPerTransaction" default:"8192"`
 }
 
-// UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (o *Options) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	if err := defaults.Set(o); err != nil {
-		return errors.Wrap(err, "can't set default database config")
-	}
-	// Prevent recursion.
-	type self Options
-	if err := unmarshal((*self)(o)); err != nil {
-		return internal.CantUnmarshalYAML(err, o)
-	}
-
+// Validate checks constraints in the supplied database options and returns an error if they are violated.
+func (o *Options) Validate() error {
 	if o.MaxConnections == 0 {
 		return errors.New("max_connections cannot be 0. Configure a value greater than zero, or use -1 for no connection limit")
 	}
 	if o.MaxConnectionsPerTable < 1 {
 		return errors.New("max_connections_per_table must be at least 1")
 	}
-
 	return nil
 }
 

--- a/pkg/icingaredis/client.go
+++ b/pkg/icingaredis/client.go
@@ -2,9 +2,7 @@ package icingaredis
 
 import (
 	"context"
-	"github.com/creasty/defaults"
 	"github.com/go-redis/redis/v8"
-	"github.com/icinga/icingadb/internal"
 	"github.com/icinga/icingadb/pkg/com"
 	"github.com/icinga/icingadb/pkg/common"
 	"github.com/icinga/icingadb/pkg/contracts"
@@ -34,17 +32,8 @@ type Options struct {
 	HScanCount          int           `yaml:"hscan_count"           default:"4096"`
 }
 
-// UnmarshalYAML implements the yaml.Unmarshaler interface.
-func (o *Options) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	if err := defaults.Set(o); err != nil {
-		return errors.Wrapf(err, "can't set defaults %#v", o)
-	}
-	// Prevent recursion.
-	type self Options
-	if err := unmarshal((*self)(o)); err != nil {
-		return internal.CantUnmarshalYAML(err, o)
-	}
-
+// Validate checks constraints in the supplied Redis options and returns an error if they are violated.
+func (o *Options) Validate() error {
 	if o.Timeout == 0 {
 		return errors.New("timeout cannot be 0. Configure a value greater than zero, or use -1 for no timeout")
 	}
@@ -57,7 +46,6 @@ func (o *Options) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	if o.HScanCount < 1 {
 		return errors.New("hscan_count must be at least 1")
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
YAML is decoded by the structure of the YAML source document, not the Go destination data structure. Therefore, the old code did not always call `UnmarshalYAML()` on all sub-structs. Therefore, defaults were not always set but zero values were used, resulting in all kind of strange behavior.

This commit changes the code so that it no longer relies on individual `UnmarshalYAML()` functions to set the defaults for each sub-struct but instead just sets all of them when creating the surrounding Config instance. It also moves the config validation to separate Validate() functions.

### Tests

<details>
<summary>Extra patch to show parsed config</summary>

```diff
diff --git a/cmd/icingadb/main.go b/cmd/icingadb/main.go
index daf7461..dcd8fbf 100644
--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -38,6 +38,7 @@ func run() int {
        defer logger.Sync()
 
        logger.Info("Starting Icinga DB")
+       logger.Debugw("Loaded config", zap.Any("config", cmd.Config))
 
        db := cmd.Database()
        defer db.Close()
```
</details>

Defaults are now set even on an empty config:
```console
% go run ./cmd/icingadb -c <(printf ---) 
2021-08-25T17:10:30.238+0200	INFO	icingadb/main.go:40	Starting Icinga DB
2021-08-25T17:10:30.238+0200	DEBUG	icingadb/main.go:41	Loaded config	{"config": {"Database":{"Host":"","Port":0,"Database":"","User":"","Password":"","Options":{"MaxConnections":16,"MaxConnectionsPerTable":8,"MaxPlaceholdersPerStatement":8192,"MaxRowsPerTransaction":8192}},"Redis":{"Address":"","Password":"","Options":{"Timeout":30000000000,"MaxHMGetConnections":4096,"HMGetCount":4096,"HScanCount":4096}}}}
```

MySQL options are still validated:
```console
$ go run ./cmd/icingadb -c <(printf 'database:\n  options:\n    max_connections: 0') 
panic: invalid configuration: max_connections cannot be 0. Configure a value greater than zero, or use -1 for no connection limit
```

Redis options are still validated:
```console
$ go run ./cmd/icingadb -c <(printf 'redis:\n  options:\n    hmget_count: 0') 
panic: invalid configuration: hmget_count must be at least 1
```

closes #346