### PR TITLE
Fix data races

### DIFF
--- a/pkg/com/counter.go
+++ b/pkg/com/counter.go
@@ -16,7 +16,7 @@ func (c *Counter) Inc() {
 }
 
 // Val returns the counter value.
-func (c Counter) Val() uint64 {
+func (c *Counter) Val() uint64 {
 	return atomic.LoadUint64(c.ptr())
 }
 

--- a/pkg/contracts/contracts.go
+++ b/pkg/contracts/contracts.go
@@ -66,6 +66,15 @@ type Waiter interface {
 	Wait() error // Wait waits for execution to complete.
 }
 
+// The WaiterFunc type is an adapter to allow the use of ordinary functions as Waiter.
+// If f is a function with the appropriate signature, WaiterFunc(f) is a Waiter that calls f.
+type WaiterFunc func() error
+
+// Wait implements the Waiter interface.
+func (f WaiterFunc) Wait() error {
+	return f()
+}
+
 // Initer implements the Init method,
 // which initializes the object in addition to zeroing.
 type Initer interface {

--- a/pkg/icingaredis/client.go
+++ b/pkg/icingaredis/client.go
@@ -63,7 +63,7 @@ type HPair struct {
 
 // HYield yields HPair field-value pairs for all fields in the hash stored at key.
 func (c *Client) HYield(ctx context.Context, key string) (<-chan HPair, <-chan error) {
-	pairs := make(chan HPair)
+	pairs := make(chan HPair, c.options.HScanCount)
 
 	c.logger.Infof("Syncing %s", key)
 

--- a/pkg/icingaredis/client.go
+++ b/pkg/icingaredis/client.go
@@ -70,9 +70,9 @@ func (c *Client) HYield(ctx context.Context, key string) (<-chan HPair, <-chan e
 	return pairs, com.WaitAsync(contracts.WaiterFunc(func() error {
 		defer close(pairs)
 
-		var cnt com.Counter
+		var cnt uint64
 		defer utils.Timed(time.Now(), func(elapsed time.Duration) {
-			c.logger.Infof("Fetched %d elements of %s in %s", cnt.Val(), key, elapsed)
+			c.logger.Infof("Fetched %d elements of %s in %s", cnt, key, elapsed)
 		})
 
 		var cursor uint64
@@ -93,7 +93,7 @@ func (c *Client) HYield(ctx context.Context, key string) (<-chan HPair, <-chan e
 					Field: page[i],
 					Value: page[i+1],
 				}:
-					cnt.Inc()
+					cnt++
 				case <-ctx.Done():
 					return ctx.Err()
 				}


### PR DESCRIPTION
This PR addresses the following data races that can occur if an ongoing config sync is canceled:

`counter.go`:

```
WARNING: DATA RACE
Read at 0x00c03212e4a0 by goroutine 786:
  github.com/icinga/icingadb/pkg/icingaredis.(*Client).HYield.func1.1()
      /Users/elippmann/Workspace/icingadb/pkg/icingaredis/client.go:57 +0xa4
  github.com/icinga/icingadb/pkg/utils.Timed()
      /Users/elippmann/Workspace/icingadb/pkg/utils/utils.go:75 +0x61
  github.com/icinga/icingadb/pkg/icingaredis.(*Client).HYield.func1()
      /Users/elippmann/Workspace/icingadb/pkg/icingaredis/client.go:71 +0x51f
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x94

Previous write at 0x00c03212e4a0 by goroutine 986:
  sync/atomic.AddInt64()
      /usr/local/Cellar/go/1.16.5/libexec/src/runtime/race_amd64.s:300 +0xb
  github.com/icinga/icingadb/pkg/com.(*Counter).Add()
      /Users/elippmann/Workspace/icingadb/pkg/com/counter.go:10 +0xa4
  github.com/icinga/icingadb/pkg/com.(*Counter).Inc()
      /Users/elippmann/Workspace/icingadb/pkg/com/counter.go:15 +0x89
  github.com/icinga/icingadb/pkg/icingaredis.(*Client).HYield.func1.2.1()
      /Users/elippmann/Workspace/icingadb/pkg/icingaredis/client.go:82 +0x88
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x94

Goroutine 786 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x73
  github.com/icinga/icingadb/pkg/icingaredis.(*Client).HYield()
      /Users/elippmann/Workspace/icingadb/pkg/icingaredis/client.go:52 +0x317
  github.com/icinga/icingadb/pkg/icingaredis.Client.YieldAll()
      /Users/elippmann/Workspace/icingadb/pkg/icingaredis/client.go:191 +0x1cb
  github.com/icinga/icingadb/pkg/icingadb.Sync.Sync()
...
```

`client.go`
```
WARNING: DATA RACE
Write at 0x00c0002018d0 by goroutine 307:
  runtime.closechan()
      /usr/local/Cellar/go/1.16.5/libexec/src/runtime/chan.go:355 +0x0
redis level handler called  github.com/icinga/icingadb/pkg/icingaredis.(*Client).HYield.func1()
      /Users/elippmann/Workspace/icingadb/pkg/icingaredis/client.go:71 +0x51f
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x94

Previous read at 0x00c0002018d0 by goroutine 266:
  runtime.chansend()
      /usr/local/Cellar/go/1.16.5/libexec/src/runtime/chan.go:158 +0x0
  github.com/icinga/icingadb/pkg/icingaredis.(*Client).HYield.func1.2.1()
      /Users/elippmann/Workspace/icingadb/pkg/icingaredis/client.go:78 +0x24c
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x94

Goroutine 307 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x73
  github.com/icinga/icingadb/pkg/icingaredis.(*Client).HYield()
      /Users/elippmann/Workspace/icingadb/pkg/icingaredis/client.go:52 +0x317
  github.com/icinga/icingadb/pkg/icingaredis.Client.YieldAll()
      /Users/elippmann/Workspace/icingadb/pkg/icingaredis/client.go:191 +0x1cb
  github.com/icinga/icingadb/pkg/icingadb.Sync.Sync()
      /User2021-07-15T13:32:50.562+0200	INFO	redis	Fetched 4021 elements of icinga:notification:user in 1.946620081s
s/elippmann/Workspace/icingadb/pkg/icingadb/sync.go:75 +0x25a
  github.com/icinga/icingadb/pkg/icingadb.Sync.SyncAfterDump()
      /Users/elippmann/Workspace/icingadb/pkg/icingadb/sync.go:61 +0xacd
  main.run.func2.5()
      /Users/elippmann/Workspace/icingadb/cmd/icingadb/main.go:238 +0x29b
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x94

Goroutine 266 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x73
  github.com/icinga/icingadb/pkg/icingaredis.(*Client).HYield.func1()
      /Users/elippmann/Workspace/icingadb/pkg/icingaredis/client.go:74 +0x492
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x94
...
```

```
panic: send on closed channel

goroutine 1469 [running]:
github.com/icinga/icingadb/pkg/icingaredis.(*Client).HYield.func1.2.1(0xc00183ef50, 0x0)
	/Users/elippmann/Workspace/icingadb/pkg/icingaredis/client.go:77 +0x2a7
golang.org/x/sync/errgroup.(*Group).Go.func1(0xc0015a7ce0, 0xc000250140)
	/Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x95
created by golang.org/x/sync/errgroup.(*Group).Go
	/Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x74
exit status 2

WARNING: DATA RACE
Write at 0x00c000218d30 by goroutine 839:
  runtime.closechan()
      /usr/local/Cellar/go/1.16.5/libexec/src/runtime/chan.go:355 +0x0
  github.com/icinga/icingadb/pkg/icingaredis.(*Client).HYield.func1()
      /Users/elippmann/Workspace/icingadb/pkg/icingaredis/client.go:71 +0x51f
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x94

Previous read at 0x00c000218d30 by goroutine 835:
  runtime.chansend()
      /usr/local/Cellar/go/1.16.5/libexec/src/runtime/chan.go:158 +0x0
  github.com/icinga/icingadb/pkg/icingaredis.(*Client).HYield.func1.2.1()
      /Users/elippmann/Workspace/icingadb/pkg/icingaredis/client.go:78 +0x24c
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x94

Goroutine 839 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x73
  github.com/icinga/icingadb/pkg/ici2021-07-16T09:22:20.288+0200	DEBUG	icingadb/delta.go:92	Synced 10501 desired elements of type NotificationUser in 3.691849548s
ngaredis.(*Client).HYield()
      /Users/elippmann/Workspace/icingadb/pkg/icingaredis/client.go:52 +0x317
  github.com/icinga/icingadb/pkg/icingaredis.Client.YieldAll()
      /Users/elippmann/Workspace/icingadb/pkg/icingaredis/client.go:191 +0x1cb
  github.com/icinga/icingadb/pkg/icingadb.Sync.Sync()
      /Users/elippmann/Workspace/icingadb/pkg/icingadb/sync.go:75 +0x25a
  github.com/icinga/icingadb/pkg/icingadb.Sync.SyncAfterDump()
      /Users/elippmann/Workspace/icingadb/pkg/icingadb/sync.go:61 +0xacd
  main.run.func1.5()
      /Users/elippmann/Workspace/icingadb/cmd/icingadb/main.go:140 +0x29b
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x94

Goroutine 835 (running) created at:
  golang.org/x/sync/errgroup.(*Group).Go()
      /Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x73
  github.com/icinga/icingadb/pkg/icingaredis.(*Client).HYield.func1()
      /Users/elippmann/Workspace/icingadb/pkg/icingaredis/client.go:74 +0x492
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /Users/elippmann/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x9
...
```