### PR TITLE
Log all different failed and recovered reconnects to backends

### DIFF
--- a/pkg/config/redis.go
+++ b/pkg/config/redis.go
@@ -66,7 +66,7 @@ func dialWithLogging(logger *zap.SugaredLogger) func(context.Context, string, st
 				return false
 			},
 			backoff.NewExponentialWithJitter(1*time.Millisecond, 1*time.Second),
-			5*time.Minute,
+			retry.Settings{Timeout: 5 * time.Minute},
 		)
 
 		err = errors.Wrap(err, "can't connect to Redis")

--- a/pkg/config/redis.go
+++ b/pkg/config/redis.go
@@ -10,7 +10,6 @@ import (
 	"go.uber.org/zap"
 	"net"
 	"os"
-	"sync"
 	"syscall"
 	"time"
 )
@@ -45,17 +44,11 @@ func dialWithLogging(logger *zap.SugaredLogger) func(context.Context, string, st
 	// dial behaves like net.Dialer#DialContext, but re-tries on syscall.ECONNREFUSED.
 	return func(ctx context.Context, network, addr string) (conn net.Conn, err error) {
 		var dl net.Dialer
-		var logFirstError sync.Once
 
 		err = retry.WithBackoff(
 			ctx,
 			func(ctx context.Context) (err error) {
 				conn, err = dl.DialContext(ctx, network, addr)
-				logFirstError.Do(func() {
-					if err != nil {
-						logger.Warnw("Can't connect to Redis. Retrying", zap.Error(err))
-					}
-				})
 				return
 			},
 			func(err error) bool {
@@ -66,7 +59,14 @@ func dialWithLogging(logger *zap.SugaredLogger) func(context.Context, string, st
 				return false
 			},
 			backoff.NewExponentialWithJitter(1*time.Millisecond, 1*time.Second),
-			retry.Settings{Timeout: 5 * time.Minute},
+			retry.Settings{
+				Timeout: 5 * time.Minute,
+				OnError: func(_ time.Duration, _ uint64, err, lastErr error) {
+					if lastErr == nil || err.Error() != lastErr.Error() {
+						logger.Warnw("Can't connect to Redis. Retrying", zap.Error(err))
+					}
+				},
+			},
 		)
 
 		err = errors.Wrap(err, "can't connect to Redis")

--- a/pkg/config/redis.go
+++ b/pkg/config/redis.go
@@ -66,6 +66,12 @@ func dialWithLogging(logger *zap.SugaredLogger) func(context.Context, string, st
 						logger.Warnw("Can't connect to Redis. Retrying", zap.Error(err))
 					}
 				},
+				OnSuccess: func(elapsed time.Duration, attempt uint64, _ error) {
+					if attempt > 0 {
+						logger.Infow("Reconnected to Redis",
+							zap.Duration("after", elapsed), zap.Uint64("attempts", attempt+1))
+					}
+				},
 			},
 		)
 

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -39,6 +39,12 @@ func (c RetryConnector) Connect(ctx context.Context) (driver.Conn, error) {
 					c.driver.Logger.Warnw("Can't connect to database. Retrying", zap.Error(err))
 				}
 			},
+			OnSuccess: func(elapsed time.Duration, attempt uint64, _ error) {
+				if attempt > 0 {
+					c.driver.Logger.Infow("Reconnected to database",
+						zap.Duration("after", elapsed), zap.Uint64("attempts", attempt+1))
+				}
+			},
 		},
 	), "can't connect to database")
 	return conn, err

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -41,7 +41,7 @@ func (c RetryConnector) Connect(ctx context.Context) (driver.Conn, error) {
 		},
 		shouldRetry,
 		backoff.NewExponentialWithJitter(time.Millisecond*128, time.Minute*1),
-		timeout,
+		retry.Settings{Timeout: timeout},
 	), "can't connect to database")
 	return conn, err
 }

--- a/pkg/icingadb/db.go
+++ b/pkg/icingadb/db.go
@@ -210,7 +210,7 @@ func (db *DB) BulkExec(ctx context.Context, query string, count int, sem *semaph
 						},
 						IsRetryable,
 						backoff.NewExponentialWithJitter(1*time.Millisecond, 1*time.Second),
-						0,
+						retry.Settings{},
 					)
 				}
 			}(b))
@@ -283,7 +283,7 @@ func (db *DB) NamedBulkExec(
 							},
 							IsRetryable,
 							backoff.NewExponentialWithJitter(1*time.Millisecond, 1*time.Second),
-							0,
+							retry.Settings{},
 						)
 					}
 				}(b))
@@ -359,7 +359,7 @@ func (db *DB) NamedBulkExecTx(
 							},
 							IsRetryable,
 							backoff.NewExponentialWithJitter(1*time.Millisecond, 1*time.Second),
-							0,
+							retry.Settings{},
 						)
 					}
 				}(b))

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -13,15 +13,20 @@ type RetryableFunc func(context.Context) error
 // IsRetryable checks whether a new attempt can be started based on the error passed.
 type IsRetryable func(error) bool
 
+// Settings aggregates optional settings for WithBackoff.
+type Settings struct {
+	// Timeout lets WithBackoff give up once elapsed (if >0).
+	Timeout time.Duration
+}
+
 // WithBackoff retries the passed function if it fails and the error allows it to retry.
 // The specified backoff policy is used to determine how long to sleep between attempts.
-// Once the specified timeout (if >0) elapses, WithBackoff gives up.
 func WithBackoff(
-	ctx context.Context, retryableFunc RetryableFunc, retryable IsRetryable, b backoff.Backoff, timeout time.Duration,
+	ctx context.Context, retryableFunc RetryableFunc, retryable IsRetryable, b backoff.Backoff, settings Settings,
 ) (err error) {
-	if timeout > 0 {
+	if settings.Timeout > 0 {
 		var cancelCtx context.CancelFunc
-		ctx, cancelCtx = context.WithTimeout(ctx, timeout)
+		ctx, cancelCtx = context.WithTimeout(ctx, settings.Timeout)
 		defer cancelCtx()
 	}
 

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -19,6 +19,8 @@ type Settings struct {
 	Timeout time.Duration
 	// OnError is called if an error occurs.
 	OnError func(elapsed time.Duration, attempt uint64, err, lastErr error)
+	// OnSuccess is called once the operation succeeds.
+	OnSuccess func(elapsed time.Duration, attempt uint64, lastErr error)
 }
 
 // WithBackoff retries the passed function if it fails and the error allows it to retry.
@@ -37,6 +39,10 @@ func WithBackoff(
 		prevErr := err
 
 		if err = retryableFunc(ctx); err == nil {
+			if settings.OnSuccess != nil {
+				settings.OnSuccess(time.Since(start), attempt, prevErr)
+			}
+
 			return
 		}
 

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -17,6 +17,8 @@ type IsRetryable func(error) bool
 type Settings struct {
 	// Timeout lets WithBackoff give up once elapsed (if >0).
 	Timeout time.Duration
+	// OnError is called if an error occurs.
+	OnError func(elapsed time.Duration, attempt uint64, err, lastErr error)
 }
 
 // WithBackoff retries the passed function if it fails and the error allows it to retry.
@@ -30,11 +32,16 @@ func WithBackoff(
 		defer cancelCtx()
 	}
 
-	for attempt := 0; ; /* true */ attempt++ {
+	start := time.Now()
+	for attempt := uint64(0); ; /* true */ attempt++ {
 		prevErr := err
 
 		if err = retryableFunc(ctx); err == nil {
 			return
+		}
+
+		if settings.OnError != nil {
+			settings.OnError(time.Since(start), attempt, err, prevErr)
 		}
 
 		isRetryable := retryable(err)
@@ -49,7 +56,7 @@ func WithBackoff(
 			return
 		}
 
-		sleep := b(uint64(attempt))
+		sleep := b(attempt)
 		select {
 		case <-ctx.Done():
 			if err == nil {


### PR DESCRIPTION
E.g. the first "connection refused", the first "hostname mismatch" and the all-clear.

fixes #351