### PR TITLE
Fix use of wrong log function on heartbeat loss

### DIFF
--- a/pkg/icingaredis/heartbeat.go
+++ b/pkg/icingaredis/heartbeat.go
@@ -146,7 +146,7 @@ func (h *Heartbeat) controller(ctx context.Context) {
 				h.beat.Broadcast()
 			case <-time.After(timeout):
 				if h.active {
-					h.logger.Warn("Lost Icinga 2 heartbeat", zap.Duration("timeout", timeout))
+					h.logger.Warnw("Lost Icinga 2 heartbeat", zap.Duration("timeout", timeout))
 					h.lost.Broadcast()
 					h.active = false
 				} else {


### PR DESCRIPTION
Has to use the `Warnw` function as it passes additional zap attributes.

### Before
```
2021-09-23T09:16:33.902+0200	WARN	icingaredis/heartbeat.go:149	Lost Icinga 2 heartbeat{timeout 8 60000000000  <nil>}
```

### After
```
2021-09-23T09:29:30.913+0200	WARN	icingaredis/heartbeat.go:149	Lost Icinga 2 heartbeat	{"timeout": "1m0s"}
```