### PR TITLE
Rewrite delta to use only a single goroutine

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/jessevdk/go-flags v1.5.0
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/pkg/errors v0.9.1
+	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.19.1
 	golang.org/x/exp v0.0.0-20210514180818-737f94c0881e
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c

--- a/pkg/icingadb/delta_test.go
+++ b/pkg/icingadb/delta_test.go
@@ -1,0 +1,266 @@
+package icingadb
+
+import (
+	"context"
+	"encoding/binary"
+	"github.com/icinga/icingadb/pkg/common"
+	"github.com/icinga/icingadb/pkg/contracts"
+	v1 "github.com/icinga/icingadb/pkg/icingadb/v1"
+	"github.com/icinga/icingadb/pkg/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"go.uber.org/zap/zaptest"
+	"strconv"
+	"sync"
+	"testing"
+)
+
+func TestDelta(t *testing.T) {
+	type TestData struct {
+		Name                   string // name for the sub-test
+		Actual, Desired        uint64 // checksum to send to actual/desired
+		Create, Update, Delete uint64 // checksum that must be in the corresponding map (if != 0)
+	}
+
+	tests := []TestData{{
+		Name: "Empty",
+	}, {
+		Name:    "Create",
+		Desired: 0x1111111111111111,
+		Create:  0x1111111111111111,
+	}, {
+		Name:    "Update",
+		Actual:  0x1111111111111111,
+		Desired: 0x2222222222222222,
+		Update:  0x2222222222222222,
+	}, {
+		Name:   "Delete",
+		Actual: 0x1111111111111111,
+		Delete: 0x1111111111111111,
+	}, {
+		Name:    "Keep",
+		Actual:  0x1111111111111111,
+		Desired: 0x1111111111111111,
+	}}
+
+	makeEndpoint := func(id, checksum uint64) *v1.Endpoint {
+		e := new(v1.Endpoint)
+		e.Id = testDeltaMakeIdOrChecksum(id)
+		e.PropertiesChecksum = testDeltaMakeIdOrChecksum(checksum)
+		return e
+	}
+
+	// Send the entities to the actual and desired channels in different ordering to catch bugs in the implementation
+	// that only show depending on the order in which actual and desired values are processed for an ID.
+	type SendOrder struct {
+		Name string
+		Send func(id uint64, test TestData, chActual, chDesired chan<- contracts.Entity)
+	}
+	sendOrders := []SendOrder{{
+		Name: "ActualFirst",
+		Send: func(id uint64, test TestData, chActual, chDesired chan<- contracts.Entity) {
+			if test.Actual != 0 {
+				chActual <- makeEndpoint(id, test.Actual)
+			}
+			if test.Desired != 0 {
+				chDesired <- makeEndpoint(id, test.Desired)
+			}
+		},
+	}, {
+		Name: "DesiredFirst",
+		Send: func(id uint64, test TestData, chActual, chDesired chan<- contracts.Entity) {
+			if test.Desired != 0 {
+				chDesired <- makeEndpoint(id, test.Desired)
+			}
+			if test.Actual != 0 {
+				chActual <- makeEndpoint(id, test.Actual)
+			}
+		},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			for _, sendOrder := range sendOrders {
+				t.Run(sendOrder.Name, func(t *testing.T) {
+					id := uint64(0x42)
+					chActual := make(chan contracts.Entity)
+					chDesired := make(chan contracts.Entity)
+					subject := common.NewSyncSubject(v1.NewEndpoint)
+					logger := zaptest.NewLogger(t).Sugar()
+
+					go func() {
+						sendOrder.Send(id, test, chActual, chDesired)
+						close(chActual)
+						close(chDesired)
+					}()
+
+					delta := NewDelta(context.Background(), chActual, chDesired, subject, logger)
+					err := delta.Wait()
+					require.NoError(t, err, "delta should finish without error")
+
+					_, ok := <-chActual
+					require.False(t, ok, "chActual should have been closed")
+					_, ok = <-chDesired
+					require.False(t, ok, "chDesired should have been closed")
+
+					testDeltaVerifyResult(t, "Create", testDeltaMakeExpectedMap(id, test.Create), delta.Create)
+					testDeltaVerifyResult(t, "Update", testDeltaMakeExpectedMap(id, test.Update), delta.Update)
+					testDeltaVerifyResult(t, "Delete", testDeltaMakeExpectedMap(id, test.Delete), delta.Delete)
+				})
+			}
+		})
+	}
+
+	t.Run("Combined", func(t *testing.T) {
+		chActual := make(chan contracts.Entity)
+		chDesired := make(chan contracts.Entity)
+		subject := common.NewSyncSubject(v1.NewEndpoint)
+		logger := zaptest.NewLogger(t).Sugar()
+
+		expectedCreate := make(map[uint64]uint64)
+		expectedUpdate := make(map[uint64]uint64)
+		expectedDelete := make(map[uint64]uint64)
+
+		nextId := uint64(1)
+		var wg sync.WaitGroup
+		for _, test := range tests {
+			test := test
+			for _, sendOrder := range sendOrders {
+				sendOrder := sendOrder
+				id := nextId
+				nextId++
+				// Log ID mapping to allow easier debugging in case of failures.
+				t.Logf("ID=%d(%s) Test=%s SendOrder=%s",
+					id, testDeltaMakeIdOrChecksum(id).String(), test.Name, sendOrder.Name)
+				wg.Add(1)
+				go func() {
+					defer wg.Done()
+					sendOrder.Send(id, test, chActual, chDesired)
+				}()
+
+				if test.Create != 0 {
+					expectedCreate[id] = test.Create
+				}
+				if test.Update != 0 {
+					expectedUpdate[id] = test.Update
+				}
+				if test.Delete != 0 {
+					expectedDelete[id] = test.Delete
+				}
+			}
+		}
+		go func() {
+			wg.Wait()
+			close(chActual)
+			close(chDesired)
+		}()
+
+		delta := NewDelta(context.Background(), chActual, chDesired, subject, logger)
+		err := delta.Wait()
+		require.NoError(t, err, "delta should finish without error")
+
+		_, ok := <-chActual
+		require.False(t, ok, "chActual should have been closed")
+		_, ok = <-chDesired
+		require.False(t, ok, "chDesired should have been closed")
+
+		testDeltaVerifyResult(t, "Create", expectedCreate, delta.Create)
+		testDeltaVerifyResult(t, "Update", expectedUpdate, delta.Update)
+		testDeltaVerifyResult(t, "Delete", expectedDelete, delta.Delete)
+	})
+}
+
+func testDeltaMakeIdOrChecksum(i uint64) types.Binary {
+	b := make([]byte, 20)
+	binary.BigEndian.PutUint64(b, i)
+	return b
+}
+
+func testDeltaMakeExpectedMap(id uint64, checksum uint64) map[uint64]uint64 {
+	if checksum == 0 {
+		return nil
+	} else {
+		return map[uint64]uint64{
+			id: checksum,
+		}
+	}
+}
+
+func testDeltaVerifyResult(t *testing.T, name string, expected map[uint64]uint64, got EntitiesById) {
+	for id, checksum := range expected {
+		idKey := testDeltaMakeIdOrChecksum(id).String()
+		if assert.Containsf(t, got, idKey, "%s: should contain %s", name, idKey) {
+			expectedChecksum := testDeltaMakeIdOrChecksum(checksum).String()
+			gotChecksum := got[idKey].(contracts.Checksumer).Checksum().String()
+			assert.Equalf(t, expectedChecksum, gotChecksum, "%s: %s should match checksum", name, idKey)
+			delete(got, idKey)
+		}
+	}
+
+	for id := range got {
+		assert.Failf(t, "unexpected element", "%s: should not contain %s", name, id)
+	}
+}
+
+func BenchmarkDelta(b *testing.B) {
+	for n := 1 << 10; n <= 1<<20; n <<= 1 {
+		b.Run(strconv.Itoa(n), func(b *testing.B) {
+			benchmarkDelta(b, n)
+		})
+	}
+}
+
+func benchmarkDelta(b *testing.B, numEntities int) {
+	chActual := make([]chan contracts.Entity, b.N)
+	chDesired := make([]chan contracts.Entity, b.N)
+	for i := 0; i < b.N; i++ {
+		chActual[i] = make(chan contracts.Entity, numEntities)
+		chDesired[i] = make(chan contracts.Entity, numEntities)
+	}
+	makeEndpoint := func(id1, id2, checksum uint64) *v1.Endpoint {
+		e := new(v1.Endpoint)
+		e.Id = make([]byte, 20)
+		binary.BigEndian.PutUint64(e.Id[0:], id1)
+		binary.BigEndian.PutUint64(e.Id[8:], id2)
+		e.PropertiesChecksum = make([]byte, 20)
+		binary.BigEndian.PutUint64(e.PropertiesChecksum, checksum)
+		return e
+	}
+	for i := 0; i < numEntities; i++ {
+		// each iteration writes exactly one entity to each channel
+		var eActual, eDesired contracts.Entity
+		switch i % 3 {
+		case 0: // distinct IDs
+			eActual = makeEndpoint(1, uint64(i), uint64(i))
+			eDesired = makeEndpoint(2, uint64(i), uint64(i))
+		case 1: // same ID, same checksum
+			e := makeEndpoint(3, uint64(i), uint64(i))
+			eActual = e
+			eDesired = e
+		case 2: // same ID, different checksum
+			eActual = makeEndpoint(4, uint64(i), uint64(i))
+			eDesired = makeEndpoint(4, uint64(i), uint64(i+1))
+		}
+		for _, ch := range chActual {
+			ch <- eActual
+		}
+		for _, ch := range chDesired {
+			ch <- eDesired
+		}
+	}
+	for i := 0; i < b.N; i++ {
+		close(chActual[i])
+		close(chDesired[i])
+	}
+	subject := common.NewSyncSubject(v1.NewEndpoint)
+	// logger := zaptest.NewLogger(b).Sugar()
+	logger := zap.New(zapcore.NewTee()).Sugar()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		d := NewDelta(context.Background(), chActual[i], chDesired[i], subject, logger)
+		err := d.Wait()
+		assert.NoError(b, err, "delta should not fail")
+	}
+}


### PR DESCRIPTION
The current delta implementation uses two goroutines that read from their own channels but update shared maps all the time. Rewriting it to just use a single goroutine make almost no difference in wall clock time (seems to even be a little faster) but removes quite a lot of lock contention so that the total CPU time needed decreases quite a bit.

For the following test, I increased the limit in the benchmark (didn't want to commit this as that test needs about 12GB RAM).

### Before
```console
$ go test -o test -c github.com/icinga/icingadb/pkg/icingadb
$ ./test -test.bench=.
goos: linux
goarch: amd64
pkg: github.com/icinga/icingadb/pkg/icingadb
cpu: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz
BenchmarkDelta/1024-8         	    1310	    793142 ns/op
BenchmarkDelta/2048-8         	     800	   1518578 ns/op
BenchmarkDelta/4096-8         	     375	   3093924 ns/op
BenchmarkDelta/8192-8         	     177	   6498656 ns/op
BenchmarkDelta/16384-8        	      81	  13897188 ns/op
BenchmarkDelta/32768-8        	      38	  29977836 ns/op
BenchmarkDelta/65536-8        	      18	  65276838 ns/op
BenchmarkDelta/131072-8       	       8	 143929741 ns/op
BenchmarkDelta/262144-8       	       4	 311318287 ns/op
BenchmarkDelta/524288-8       	       2	 677328462 ns/op
BenchmarkDelta/1048576-8      	       1	1581513429 ns/op
BenchmarkDelta/2097152-8      	       1	3370276475 ns/op
BenchmarkDelta/4194304-8      	       1	7291033169 ns/op
BenchmarkDelta/8388608-8      	       1	15628877888 ns/op
BenchmarkDelta/16777216-8     	       1	33995732865 ns/op
PASS
$ \time -v ./test -test.bench=BenchmarkDelta/16777216
goos: linux
goarch: amd64
pkg: github.com/icinga/icingadb/pkg/icingadb
cpu: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz
BenchmarkDelta/16777216-8         	       1	32999606020 ns/op
PASS
	Command being timed: "./test -test.bench=BenchmarkDelta/16777216"
	User time (seconds): 81.54
	System time (seconds): 5.71
	Percent of CPU this job got: 222%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:39.26
[...]
```

### After
```console
$ go test -o test -c github.com/icinga/icingadb/pkg/icingadb
$ ./test -test.bench=.
goos: linux
goarch: amd64
pkg: github.com/icinga/icingadb/pkg/icingadb
cpu: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz
BenchmarkDelta/1024-8         	    1412	    746115 ns/op
BenchmarkDelta/2048-8         	     753	   1449967 ns/op
BenchmarkDelta/4096-8         	     379	   2929251 ns/op
BenchmarkDelta/8192-8         	     178	   6508426 ns/op
BenchmarkDelta/16384-8        	      92	  14127214 ns/op
BenchmarkDelta/32768-8        	      37	  30665427 ns/op
BenchmarkDelta/65536-8        	      18	  64991758 ns/op
BenchmarkDelta/131072-8       	       8	 137032624 ns/op
BenchmarkDelta/262144-8       	       4	 291233974 ns/op
BenchmarkDelta/524288-8       	       2	 642120690 ns/op
BenchmarkDelta/1048576-8      	       1	1545381880 ns/op
BenchmarkDelta/2097152-8      	       1	3273877521 ns/op
BenchmarkDelta/4194304-8      	       1	6717818583 ns/op
BenchmarkDelta/8388608-8      	       1	14430346934 ns/op
BenchmarkDelta/16777216-8     	       1	31069273615 ns/op
PASS
$ \time -v ./test -test.bench=BenchmarkDelta/16777216
goos: linux
goarch: amd64
pkg: github.com/icinga/icingadb/pkg/icingadb
cpu: Intel(R) Core(TM) i7-10510U CPU @ 1.80GHz
BenchmarkDelta/16777216-8         	       1	30448680513 ns/op
PASS
	Command being timed: "./test -test.bench=BenchmarkDelta/16777216"
	User time (seconds): 65.70
	System time (seconds): 4.16
	Percent of CPU this job got: 193%
	Elapsed (wall clock) time (h:mm:ss or m:ss): 0:36.20
[...]
```

### Comparison

| Test         | Before   | After    | Change |
| ------------ | -------- | -------- | ------ |
| n = 1024     |   793 us |   746 us | -5.9 % |
| n = 2048     |  1518 us |  1449 us | -4.5 % |
| n = 4096     |  3093 us |  2929 us | -5.3 % |
| n = 8192     |  6498 us |  6508 us | +0.1 % |
| n = 16384    | 13897 us | 14127 us | +1.6 % |
| n = 32768    | 29977 us | 30665 us | +2.2 % |
| n = 65536    | 65276 us | 64991 us | -0.4 % |
| n = 131072   |   143 ms |   137 ms | -4.7 % |
| n = 262144   |   311 ms |   291 ms | -6.4 % |
| n = 524288   |   677 ms |   642 ms | -5.1 % |
| n = 1048576  |  1581 ms |  1545 ms | -2.2 % |
| n = 2097152  |  3370 ms |  3273 ms | -2.8 % |
| n = 4194304  |  7291 ms |  6717 ms | -7.8 % |
| n = 8388608  | 15628 ms | 14430 ms | -7.6 % |
| n = 16777216 | 33995 ms | 31069 ms | -8.6 % |

(Don't give too much on the exact numbers, that was just a single run but it matches my general impression from multiple runs: there's no huge change but it tends to even be slightly faster.)

Also the CPU time (user+sys) went from 87.25s to 69.86s (-20 %), that's the main benefit of this PR.

refs #361 (Making delta single-threaded was originally part of that PR but now got moved here. There's a bit of history/context over there.)