### PR TITLE
Schema: s/mediumtext/longtext/

### DIFF
--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -129,10 +129,10 @@ CREATE TABLE host_state (
   attempt tinyint unsigned NOT NULL,
   severity smallint unsigned NOT NULL,
 
-  output mediumtext DEFAULT NULL,
-  long_output mediumtext DEFAULT NULL,
-  performance_data mediumtext DEFAULT NULL,
-  normalized_performance_data mediumtext DEFAULT NULL,
+  output longtext DEFAULT NULL,
+  long_output longtext DEFAULT NULL,
+  performance_data longtext DEFAULT NULL,
+  normalized_performance_data longtext DEFAULT NULL,
   check_commandline text DEFAULT NULL,
 
   is_problem enum('n', 'y') NOT NULL,
@@ -283,10 +283,10 @@ CREATE TABLE service_state (
   attempt tinyint unsigned NOT NULL,
   severity smallint unsigned NOT NULL,
 
-  output mediumtext DEFAULT NULL,
-  long_output mediumtext DEFAULT NULL,
-  performance_data mediumtext DEFAULT NULL,
-  normalized_performance_data mediumtext DEFAULT NULL,
+  output longtext DEFAULT NULL,
+  long_output longtext DEFAULT NULL,
+  performance_data longtext DEFAULT NULL,
+  normalized_performance_data longtext DEFAULT NULL,
 
   check_commandline text DEFAULT NULL,
 
@@ -933,8 +933,8 @@ CREATE TABLE state_history (
   previous_soft_state tinyint unsigned NOT NULL,
   previous_hard_state tinyint unsigned NOT NULL,
   attempt tinyint unsigned NOT NULL,
-  output mediumtext DEFAULT NULL,
-  long_output mediumtext DEFAULT NULL,
+  output longtext DEFAULT NULL,
+  long_output longtext DEFAULT NULL,
   max_check_attempts int unsigned NOT NULL,
   check_source text DEFAULT NULL,
   scheduling_source text DEFAULT NULL,

--- a/schema/mysql/upgrades/1.0.0-rc2.sql
+++ b/schema/mysql/upgrades/1.0.0-rc2.sql
@@ -49,7 +49,7 @@ ALTER TABLE host
     MODIFY perfdata_enabled enum('n','y') NOT NULL,
     MODIFY is_volatile enum('n','y') NOT NULL;
 ALTER TABLE host_state
-    ADD COLUMN normalized_performance_data mediumtext DEFAULT NULL AFTER performance_data,
+    ADD COLUMN normalized_performance_data longtext DEFAULT NULL AFTER performance_data,
     ADD COLUMN last_comment_id binary(20) DEFAULT NULL COMMENT 'comment.id' AFTER acknowledgement_comment_id,
     ADD COLUMN scheduling_source text DEFAULT NULL AFTER check_source,
     MODIFY is_problem enum('n','y') NOT NULL,
@@ -68,7 +68,7 @@ ALTER TABLE service
     MODIFY perfdata_enabled enum('n','y') NOT NULL,
     MODIFY is_volatile enum('n','y') NOT NULL;
 ALTER TABLE service_state
-    ADD COLUMN normalized_performance_data mediumtext DEFAULT NULL AFTER performance_data,
+    ADD COLUMN normalized_performance_data longtext DEFAULT NULL AFTER performance_data,
     ADD COLUMN last_comment_id binary(20) DEFAULT NULL COMMENT 'comment.id' AFTER acknowledgement_comment_id,
     ADD COLUMN scheduling_source text DEFAULT NULL AFTER check_source,
     MODIFY is_problem enum('n','y') NOT NULL,
@@ -131,16 +131,16 @@ INSERT INTO icingadb_schema (version, timestamp)
   VALUES (2, CURRENT_TIMESTAMP() * 1000);
 
 ALTER TABLE host_state
-    MODIFY output mediumtext DEFAULT NULL,
-    MODIFY long_output mediumtext DEFAULT NULL,
-    MODIFY performance_data mediumtext DEFAULT NULL;
+    MODIFY output longtext DEFAULT NULL,
+    MODIFY long_output longtext DEFAULT NULL,
+    MODIFY performance_data longtext DEFAULT NULL;
 
 ALTER TABLE state_history
     ADD COLUMN scheduling_source text DEFAULT NULL AFTER check_source,
-    MODIFY output mediumtext DEFAULT NULL,
-    MODIFY long_output mediumtext DEFAULT NULL;
+    MODIFY output longtext DEFAULT NULL,
+    MODIFY long_output longtext DEFAULT NULL;
 
 ALTER TABLE service_state
-    MODIFY output mediumtext DEFAULT NULL,
-    MODIFY long_output mediumtext DEFAULT NULL,
-    MODIFY performance_data mediumtext DEFAULT NULL;
+    MODIFY output longtext DEFAULT NULL,
+    MODIFY long_output longtext DEFAULT NULL,
+    MODIFY performance_data longtext DEFAULT NULL;


### PR DESCRIPTION
... to make MySQL storage capabilities of likely large text columns more similar (16MB -> 4GB) to (upcoming) Postgres ones (unlimited) and not to have to pre-truncate anything.

fixes #260
closes #218