### PR TITLE
Reliably handle heartbeat events in HA and stop writing a heartbeat to the DB after it expires and hand over

### DIFF
--- a/pkg/icingadb/ha.go
+++ b/pkg/icingadb/ha.go
@@ -147,7 +147,13 @@ func (h *HA) controller() {
 				default:
 				}
 
-				realizeCtx, cancelRealizeCtx := context.WithDeadline(h.ctx, m.ExpiryTime())
+				var realizeCtx context.Context
+				var cancelRealizeCtx context.CancelFunc
+				if h.responsible {
+					realizeCtx, cancelRealizeCtx = context.WithDeadline(h.ctx, m.ExpiryTime())
+				} else {
+					realizeCtx, cancelRealizeCtx = context.WithCancel(h.ctx)
+				}
 				err = h.realize(realizeCtx, s, t, shouldLog)
 				cancelRealizeCtx()
 				if errors.Is(err, context.DeadlineExceeded) {

--- a/pkg/icingadb/ha.go
+++ b/pkg/icingadb/ha.go
@@ -123,7 +123,7 @@ func (h *HA) controller() {
 		case m := <-h.heartbeat.Events():
 			if m != nil {
 				now := time.Now()
-				t, err := m.Time()
+				t, err := m.Stats().Time()
 				if err != nil {
 					h.abort(err)
 				}
@@ -136,7 +136,7 @@ func (h *HA) controller() {
 					h.signalHandover()
 					continue
 				}
-				s, err := m.IcingaStatus()
+				s, err := m.Stats().IcingaStatus()
 				if err != nil {
 					h.abort(err)
 				}


### PR DESCRIPTION
The first commit in the series replaces the functions `Beat()`, `Loss()` and `Message()` on `Heartbeat` with a single `Events()` function that returns a channel to which (a) a non-nil pointer is sent for each heartbeat and (b) a nil pointer is sent on a heartbeat loss. This allows the HA code to not miss any heartbeat loss events (technically it can still miss one but only if it fails to receive from the channel before an other heartbeat is received from Icinga 2, but in this case the information of a heartbeat loss became obsolete anyways).

The remaining three commits add a timeout for writing a heartbeat to the SQL database (happening in `HA.realize()`). If this does not finish before the heartbeat expires, it (a) gives up writing to the database and (b) signals a handover to the local Icinga DB instance as writing is too slow to still signal other instances that this one is active.

fixes #360
closes #371