### PR TITLE
Remove example configuration from docs

### DIFF
--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -3,6 +3,7 @@
 ## Overview <a id="configuration-overview"></a>
 
 The configuration is stored in `/etc/icingadb/icingadb.yml`.
+See [config.yml.example](../config.yml.example) for an example configuration.
 
 ## Redis Configuration <a id="configuration-redis"></a>
 
@@ -23,16 +24,3 @@ port                     | **Required.** Database port.
 database                 | **Required.** Database database.
 user                     | **Required.** Database username.
 password                 | **Required.** Database password.
-
-## Example Configuration <a id="configuration-example"></a>
-
-```yaml
-database:
-  host: icingadb
-  port: 3306
-  database: icingadb
-  user: icingadb
-  password: icingadb
-redis:
-  address: redis:6380
-```


### PR DESCRIPTION
We already have config.yml.example as a source to copy and paste
so one can get started easily. In addition,
only one place has to be maintained for the example configuration.

This PR should be merged before #366.