### PR TITLE
Schema: Prefix command_id with command type (check, event, notification)

### DIFF
--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -26,7 +26,7 @@ import (
 const (
 	ExitSuccess                = 0
 	ExitFailure                = 1
-	expectedRedisSchemaVersion = "3"
+	expectedRedisSchemaVersion = "4"
 	expectedDbSchemaVersion    = 2
 )
 

--- a/pkg/icingadb/v1/command.go
+++ b/pkg/icingadb/v1/command.go
@@ -17,7 +17,6 @@ type Command struct {
 type CommandArgument struct {
 	EntityWithChecksum  `json:",inline"`
 	EnvironmentMeta     `json:",inline"`
-	CommandId           types.Binary `json:"command_id"`
 	ArgumentKey         string       `json:"argument_key"`
 	ArgumentValue       types.String `json:"value"`
 	ArgumentOrder       types.Int    `json:"order"`
@@ -50,14 +49,8 @@ func (ca *CommandArgument) Init() {
 type CommandEnvvar struct {
 	EntityWithChecksum `json:",inline"`
 	EnvironmentMeta    `json:",inline"`
-	CommandId          types.Binary `json:"command_id"`
-	EnvvarKey          string       `json:"envvar_key"`
-	EnvvarValue        string       `json:"value"`
-}
-
-type CommandCustomvar struct {
-	CustomvarMeta `json:",inline"`
-	CommandId     types.Binary `json:"command_id"`
+	EnvvarKey          string `json:"envvar_key"`
+	EnvvarValue        string `json:"value"`
 }
 
 type Checkcommand struct {
@@ -66,14 +59,17 @@ type Checkcommand struct {
 
 type CheckcommandArgument struct {
 	CommandArgument `json:",inline"`
+	CheckcommandId  types.Binary `json:"checkcommand_id"`
 }
 
 type CheckcommandEnvvar struct {
-	CommandEnvvar `json:",inline"`
+	CommandEnvvar  `json:",inline"`
+	CheckcommandId types.Binary `json:"checkcommand_id"`
 }
 
 type CheckcommandCustomvar struct {
-	CommandCustomvar `json:",inline"`
+	CustomvarMeta  `json:",inline"`
+	CheckcommandId types.Binary `json:"checkcommand_id"`
 }
 
 type Eventcommand struct {
@@ -82,14 +78,17 @@ type Eventcommand struct {
 
 type EventcommandArgument struct {
 	CommandArgument `json:",inline"`
+	EventcommandId  types.Binary `json:"eventcommand_id"`
 }
 
 type EventcommandEnvvar struct {
-	CommandEnvvar `json:",inline"`
+	CommandEnvvar  `json:",inline"`
+	EventcommandId types.Binary `json:"eventcommand_id"`
 }
 
 type EventcommandCustomvar struct {
-	CommandCustomvar `json:",inline"`
+	CustomvarMeta  `json:",inline"`
+	EventcommandId types.Binary `json:"eventcommand_id"`
 }
 
 type Notificationcommand struct {
@@ -97,15 +96,18 @@ type Notificationcommand struct {
 }
 
 type NotificationcommandArgument struct {
-	CommandArgument `json:",inline"`
+	CommandArgument       `json:",inline"`
+	NotificationcommandId types.Binary `json:"notificationcommand_id"`
 }
 
 type NotificationcommandEnvvar struct {
-	CommandEnvvar `json:",inline"`
+	CommandEnvvar         `json:",inline"`
+	NotificationcommandId types.Binary `json:"notificationcommand_id"`
 }
 
 type NotificationcommandCustomvar struct {
-	CommandCustomvar `json:",inline"`
+	CustomvarMeta         `json:",inline"`
+	NotificationcommandId types.Binary `json:"notificationcommand_id"`
 }
 
 func NewCheckcommand() contracts.Entity {

--- a/pkg/icingadb/v1/notification.go
+++ b/pkg/icingadb/v1/notification.go
@@ -6,19 +6,19 @@ import (
 )
 
 type Notification struct {
-	EntityWithChecksum   `json:",inline"`
-	EnvironmentMeta      `json:",inline"`
-	NameCiMeta           `json:",inline"`
-	HostId               types.Binary             `json:"host_id"`
-	ServiceId            types.Binary             `json:"service_id"`
-	CommandId            types.Binary             `json:"command_id"`
-	TimesBegin           types.Int                `json:"times_begin"`
-	TimesEnd             types.Int                `json:"times_end"`
-	NotificationInterval uint32                   `json:"notification_interval"`
-	TimeperiodId         types.Binary             `json:"timeperiod_id"`
-	States               types.NotificationStates `json:"states"`
-	Types                types.NotificationTypes  `json:"types"`
-	ZoneId               types.Binary             `json:"zone_id"`
+	EntityWithChecksum    `json:",inline"`
+	EnvironmentMeta       `json:",inline"`
+	NameCiMeta            `json:",inline"`
+	HostId                types.Binary             `json:"host_id"`
+	ServiceId             types.Binary             `json:"service_id"`
+	NotificationcommandId types.Binary             `json:"notificationcommand_id"`
+	TimesBegin            types.Int                `json:"times_begin"`
+	TimesEnd              types.Int                `json:"times_end"`
+	NotificationInterval  uint32                   `json:"notification_interval"`
+	TimeperiodId          types.Binary             `json:"timeperiod_id"`
+	States                types.NotificationStates `json:"states"`
+	Types                 types.NotificationTypes  `json:"types"`
+	ZoneId                types.Binary             `json:"zone_id"`
 }
 
 type NotificationUser struct {

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -391,9 +391,9 @@ CREATE TABLE checkcommand (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE checkcommand_argument (
-  id binary(20) NOT NULL COMMENT 'sha1(environment.id + command_id + argument_key)',
+  id binary(20) NOT NULL COMMENT 'sha1(environment.id + checkcommand_id + argument_key)',
   environment_id binary(20) NOT NULL COMMENT 'env.id',
-  command_id binary(20) NOT NULL COMMENT 'command.id',
+  checkcommand_id binary(20) NOT NULL COMMENT 'checkcommand.id',
   argument_key varchar(64) NOT NULL,
 
   properties_checksum binary(20) NOT NULL COMMENT 'sha1(all properties)',
@@ -411,9 +411,9 @@ CREATE TABLE checkcommand_argument (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE checkcommand_envvar (
-  id binary(20) NOT NULL COMMENT 'sha1(environment.id + command_id + envvar_key)',
+  id binary(20) NOT NULL COMMENT 'sha1(environment.id + checkcommand_id + envvar_key)',
   environment_id binary(20) NOT NULL COMMENT 'env.id',
-  command_id binary(20) NOT NULL COMMENT 'command.id',
+  checkcommand_id binary(20) NOT NULL COMMENT 'checkcommand.id',
   envvar_key varchar(64) NOT NULL,
 
   properties_checksum binary(20) NOT NULL COMMENT 'sha1(all properties)',
@@ -424,16 +424,16 @@ CREATE TABLE checkcommand_envvar (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE checkcommand_customvar (
-  id binary(20) NOT NULL COMMENT 'sha1(environment.id + command_id + customvar_id)',
+  id binary(20) NOT NULL COMMENT 'sha1(environment.id + checkcommand_id + customvar_id)',
   environment_id binary(20) NOT NULL COMMENT 'environment.id',
 
-  command_id binary(20) NOT NULL COMMENT 'command.id',
+  checkcommand_id binary(20) NOT NULL COMMENT 'checkcommand.id',
   customvar_id binary(20) NOT NULL COMMENT 'customvar.id',
 
   PRIMARY KEY (id),
 
-  INDEX idx_checkcommand_customvar_command_id (command_id, customvar_id),
-  INDEX idx_checkcommand_customvar_customvar_id (customvar_id, command_id)
+  INDEX idx_checkcommand_customvar_checkcheckcommand_id (checkcommand_id, customvar_id),
+  INDEX idx_checkcommand_customvar_customvar_id (customvar_id, checkcommand_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 
@@ -454,9 +454,9 @@ CREATE TABLE eventcommand (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE eventcommand_argument (
-  id binary(20) NOT NULL COMMENT 'sha1(environment.id + command_id + argument_key)',
+  id binary(20) NOT NULL COMMENT 'sha1(environment.id + eventcommand_id + argument_key)',
   environment_id binary(20) NOT NULL COMMENT 'env.id',
-  command_id binary(20) NOT NULL COMMENT 'command.id',
+  eventcommand_id binary(20) NOT NULL COMMENT 'eventcommand.id',
   argument_key varchar(64) NOT NULL,
 
   properties_checksum binary(20) NOT NULL COMMENT 'sha1(all properties)',
@@ -474,9 +474,9 @@ CREATE TABLE eventcommand_argument (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE eventcommand_envvar (
-  id binary(20) NOT NULL COMMENT 'sha1(environment.id + command_id + envvar_key)',
+  id binary(20) NOT NULL COMMENT 'sha1(environment.id + eventcommand_id + envvar_key)',
   environment_id binary(20) NOT NULL COMMENT 'env.id',
-  command_id binary(20) NOT NULL COMMENT 'command.id',
+  eventcommand_id binary(20) NOT NULL COMMENT 'eventcommand.id',
   envvar_key varchar(64) NOT NULL,
 
   properties_checksum binary(20) NOT NULL COMMENT 'sha1(all properties)',
@@ -487,15 +487,15 @@ CREATE TABLE eventcommand_envvar (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE eventcommand_customvar (
-  id binary(20) NOT NULL COMMENT 'sha1(environment.id + command_id + customvar_id)',
+  id binary(20) NOT NULL COMMENT 'sha1(environment.id + eventcommand_id + customvar_id)',
   environment_id binary(20) NOT NULL COMMENT 'environment.id',
-  command_id binary(20) NOT NULL COMMENT 'command.id',
+  eventcommand_id binary(20) NOT NULL COMMENT 'eventcommand.id',
   customvar_id binary(20) NOT NULL COMMENT 'customvar.id',
 
   PRIMARY KEY (id),
 
-  INDEX idx_eventcommand_customvar_command_id (command_id, customvar_id),
-  INDEX idx_eventcommand_customvar_customvar_id (customvar_id, command_id)
+  INDEX idx_eventcommand_customvar_eventcommand_id (eventcommand_id, customvar_id),
+  INDEX idx_eventcommand_customvar_customvar_id (customvar_id, eventcommand_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE notificationcommand (
@@ -515,9 +515,9 @@ CREATE TABLE notificationcommand (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE notificationcommand_argument (
-  id binary(20) NOT NULL COMMENT 'sha1(environment.id + command_id + argument_key)',
+  id binary(20) NOT NULL COMMENT 'sha1(environment.id + notificationcommand_id + argument_key)',
   environment_id binary(20) NOT NULL COMMENT 'env.id',
-  command_id binary(20) NOT NULL COMMENT 'command.id',
+  notificationcommand_id binary(20) NOT NULL COMMENT 'notificationcommand.id',
   argument_key varchar(64) NOT NULL,
 
   properties_checksum binary(20) NOT NULL COMMENT 'sha1(all properties)',
@@ -535,9 +535,9 @@ CREATE TABLE notificationcommand_argument (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE notificationcommand_envvar (
-  id binary(20) NOT NULL COMMENT 'sha1(environment.id + command_id + envvar_key)',
+  id binary(20) NOT NULL COMMENT 'sha1(environment.id + notificationcommand_id + envvar_key)',
   environment_id binary(20) NOT NULL COMMENT 'env.id',
-  command_id binary(20) NOT NULL COMMENT 'command.id',
+  notificationcommand_id binary(20) NOT NULL COMMENT 'notificationcommand.id',
   envvar_key varchar(64) NOT NULL,
 
   properties_checksum binary(20) NOT NULL COMMENT 'sha1(all properties)',
@@ -548,15 +548,15 @@ CREATE TABLE notificationcommand_envvar (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE notificationcommand_customvar (
-  id binary(20) NOT NULL COMMENT 'sha1(environment.id + command_id + customvar_id)',
+  id binary(20) NOT NULL COMMENT 'sha1(environment.id + notificationcommand_id + customvar_id)',
   environment_id binary(20) NOT NULL COMMENT 'environment.id',
-  command_id binary(20) NOT NULL COMMENT 'command.id',
+  notificationcommand_id binary(20) NOT NULL COMMENT 'notificationcommand.id',
   customvar_id binary(20) NOT NULL COMMENT 'customvar.id',
 
   PRIMARY KEY (id),
 
-  INDEX idx_notificationcommand_customvar_command_id (command_id, customvar_id),
-  INDEX idx_notificationcommand_customvar_customvar_id (customvar_id, command_id)
+  INDEX idx_notificationcommand_customvar_notificationcommand_id (notificationcommand_id, customvar_id),
+  INDEX idx_notificationcommand_customvar_customvar_id (customvar_id, notificationcommand_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE comment (
@@ -633,7 +633,7 @@ CREATE TABLE notification (
 
   host_id binary(20) NOT NULL COMMENT 'host.id',
   service_id binary(20) DEFAULT NULL COMMENT 'service.id',
-  command_id binary(20) NOT NULL COMMENT 'command.id',
+  notificationcommand_id binary(20) NOT NULL COMMENT 'notificationcommand.id',
 
   times_begin int unsigned DEFAULT NULL,
   times_end int unsigned DEFAULT NULL,

--- a/schema/mysql/upgrades/1.0.0-rc2.sql
+++ b/schema/mysql/upgrades/1.0.0-rc2.sql
@@ -322,3 +322,88 @@ ALTER TABLE flapping_history
     MODIFY id binary(20) NOT NULL COMMENT 'sha1(environment.id + "Host"|"Service" + host|service.name + start_time)';
 ALTER TABLE acknowledgement_history
     MODIFY id binary(20) NOT NULL COMMENT 'sha1(environment.id + "Host"|"Service" + host|service.name + set_time)';
+
+/*
+ * Schema changes after https://github.com/Icinga/icingadb/pull/403:
+ */
+
+ALTER TABLE checkcommand_customvar
+    DROP INDEX idx_checkcommand_customvar_command_id,
+    DROP INDEX idx_checkcommand_customvar_customvar_id;
+
+ALTER TABLE eventcommand_customvar
+    DROP INDEX idx_eventcommand_customvar_command_id,
+    DROP INDEX idx_eventcommand_customvar_customvar_id;
+
+ALTER TABLE notificationcommand_customvar
+    DROP INDEX idx_notificationcommand_customvar_command_id,
+    DROP INDEX idx_notificationcommand_customvar_id;
+
+ALTER TABLE notification
+    RENAME COLUMN command_id TO notificationcommand_id;
+
+ALTER TABLE checkcommand_argument
+    RENAME COLUMN command_id TO checkcommand_id;
+ALTER TABLE checkcommand_argument
+    MODIFY checkcommand_id binary(20) NOT NULL COMMENT 'checkcommand.id',
+    MODIFY id binary(20) NOT NULL COMMENT 'sha1(environment.id + checkcommand_id + argument_key)';
+
+ALTER TABLE checkcommand_envvar
+    RENAME COLUMN command_id TO checkcommand_id;
+ALTER TABLE checkcommand_envvar
+    MODIFY checkcommand_id binary(20) NOT NULL COMMENT 'checkcommand.id',
+    MODIFY id binary(20) NOT NULL COMMENT 'sha1(environment.id + checkcommand_id + envvar_key)';
+
+ALTER TABLE checkcommand_customvar
+    RENAME COLUMN command_id TO checkcommand_id;
+ALTER TABLE checkcommand_customvar
+    MODIFY checkcommand_id binary(20) NOT NULL COMMENT 'checkcommand.id',
+    MODIFY id binary(20) NOT NULL COMMENT 'sha1(environment.id + checkcommand_id + customvar_id)';
+
+ALTER TABLE eventcommand_argument
+    RENAME COLUMN command_id TO eventcommand_id;
+ALTER TABLE eventcommand_argument
+    MODIFY eventcommand_id binary(20) NOT NULL COMMENT 'eventcommand.id',
+    MODIFY id binary(20) NOT NULL COMMENT 'sha1(environment.id + eventcommand_id + argument_key)';
+
+ALTER TABLE eventcommand_envvar
+    RENAME COLUMN command_id TO eventcommand_id;
+ALTER TABLE eventcommand_envvar
+    MODIFY eventcommand_id binary(20) NOT NULL COMMENT 'eventcommand.id',
+    MODIFY id binary(20) NOT NULL COMMENT 'sha1(environment.id + eventcommand_id + envvar_key)';
+
+ALTER TABLE eventcommand_customvar
+    RENAME COLUMN command_id TO eventcommand_id;
+ALTER TABLE eventcommand_customvar
+    MODIFY eventcommand_id binary(20) NOT NULL COMMENT 'eventcommand.id',
+    MODIFY id binary(20) NOT NULL COMMENT 'sha1(environment.id + eventcommand_id + customvar_id)';
+
+ALTER TABLE notificationcommand_argument
+    RENAME COLUMN command_id TO notificationcommand_id;
+ALTER TABLE notificationcommand_argument
+    MODIFY notificationcommand_id binary(20) NOT NULL COMMENT 'notificationcommand.id',
+    MODIFY id binary(20) NOT NULL COMMENT 'sha1(environment.id + notificationcommand_id + argument_key)';
+
+ALTER TABLE notificationcommand_envvar
+    RENAME COLUMN command_id TO notificationcommand_id;
+ALTER TABLE notificationcommand_envvar
+    MODIFY notificationcommand_id binary(20) NOT NULL COMMENT 'notificationcommand.id',
+    MODIFY id binary(20) NOT NULL COMMENT 'sha1(environment.id + notificationcommand_id + envvar_key)';
+
+ALTER TABLE notificationcommand_customvar
+    RENAME COLUMN command_id TO notificationcommand_id;
+ALTER TABLE notificationcommand_customvar
+    MODIFY notificationcommand_id binary(20) NOT NULL COMMENT 'notificationcommand.id',
+    MODIFY id binary(20) NOT NULL COMMENT 'sha1(environment.id + notificationcommand_id + customvar_id)';
+
+ALTER TABLE checkcommand_customvar
+    ADD INDEX idx_checkcommand_customvar_checkcommand_id (checkcommand_id, customvar_id),
+    ADD INDEX idx_checkcommand_customvar_customvar_id (customvar_id, checkcommand_id);
+
+ALTER TABLE eventcommand_customvar
+    ADD INDEX idx_eventcommand_customvar_eventcommand_id (eventcommand_id, customvar_id),
+    ADD INDEX idx_eventcommand_customvar_customvar_id (customvar_id, eventcommand_id);
+
+ALTER TABLE notificationcommand_customvar
+    ADD INDEX idx_notificationcommand_customvar_notificationcommand_id (notificationcommand_id, customvar_id),
+    ADD INDEX idx_notificationcommand_customvar_customvar_id (customvar_id, notificationcommand_id);


### PR DESCRIPTION
This PR changes the command reference IDs to `{check,notification,event}command_id` to have unified reference IDs (`{tablename}_id`) across our schema where possible.

- PR Icinga 2: https://github.com/Icinga/icinga2/pull/9058
- PR Icinga DB Web: https://github.com/Icinga/icingadb-web/pull/406

TODO:
- [x] Increase Redis schema version when https://github.com/Icinga/icingadb/pull/391 has been merged