### PR TITLE
Integration tests for history sync in HA setups

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/containerd v1.5.6 // indirect
 	github.com/go-redis/redis/v8 v8.11.3
 	github.com/google/uuid v1.3.0
-	github.com/icinga/icinga-testing v0.0.0-20211111113205-9914911dc718
+	github.com/icinga/icinga-testing v0.0.0-20211112112017-64c69fdac3ca
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.19.1

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -390,8 +390,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/icinga/icinga-testing v0.0.0-20211111113205-9914911dc718 h1:BbxprPPO6kBPU81ejEpIxj1d4dmf1zTds9ci6HzCZ88=
-github.com/icinga/icinga-testing v0.0.0-20211111113205-9914911dc718/go.mod h1:VzB7xVUPFvAUgX1nDrheKHpQddvUIN24Sei4mLGelpo=
+github.com/icinga/icinga-testing v0.0.0-20211112112017-64c69fdac3ca h1:8EXQTKEqUkmF/9/9iIQNPKT0BF2AY9/zunbpcRx+fcI=
+github.com/icinga/icinga-testing v0.0.0-20211112112017-64c69fdac3ca/go.mod h1:VzB7xVUPFvAUgX1nDrheKHpQddvUIN24Sei4mLGelpo=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/tests/history_test_zones.conf
+++ b/tests/history_test_zones.conf
@@ -1,0 +1,22 @@
+{{range .}}
+object Endpoint "{{.Name}}" {
+	host = "{{.Icinga2.Host}}"
+	port = "{{.Icinga2.Port}}"
+}
+{{end}}
+
+object Zone "master" {
+	endpoints = [
+{{range .}}
+		"{{.Name}}",
+{{end}}
+	]
+}
+
+object Zone "global-templates" {
+	global = true
+}
+
+object Zone "director-global" {
+	global = true
+}


### PR DESCRIPTION
This PR extends the existing history sync integration tests so that these are also run with an icinga2 HA cluster to check that even in this case, no duplicates are written to MySQL.

This served as my tests for the following pull requests:
* #392 (merged into this PR for testing)
* #393 (merged into this PR for testing)
* https://github.com/Icinga/icinga2/pull/9029 (the `icinga2:git-v2.13.0-77-ga17592fe7` Docker image is a build of that PR merged with the current master (https://github.com/Icinga/icinga2/commit/b5132a59ef72737fd7c3415cf101c5c1ff1c32dc)

### Blocked by
* https://github.com/Icinga/icinga-testing/pull/7