### PR TITLE
Schema: Fix index typos + missing comment change

### DIFF
--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -432,7 +432,7 @@ CREATE TABLE checkcommand_customvar (
 
   PRIMARY KEY (id),
 
-  INDEX idx_checkcommand_customvar_checkcheckcommand_id (checkcommand_id, customvar_id),
+  INDEX idx_checkcommand_customvar_checkcommand_id (checkcommand_id, customvar_id),
   INDEX idx_checkcommand_customvar_customvar_id (customvar_id, checkcommand_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 

--- a/schema/mysql/upgrades/1.0.0-rc2.sql
+++ b/schema/mysql/upgrades/1.0.0-rc2.sql
@@ -337,10 +337,12 @@ ALTER TABLE eventcommand_customvar
 
 ALTER TABLE notificationcommand_customvar
     DROP INDEX idx_notificationcommand_customvar_command_id,
-    DROP INDEX idx_notificationcommand_customvar_id;
+    DROP INDEX idx_notificationcommand_customvar_customvar_id;
 
 ALTER TABLE notification
     RENAME COLUMN command_id TO notificationcommand_id;
+ALTER TABLE notification
+    MODIFY notificationcommand_id binary(20) NOT NULL COMMENT 'notificationcommand.id';
 
 ALTER TABLE checkcommand_argument
     RENAME COLUMN command_id TO checkcommand_id;


### PR DESCRIPTION
This PR fixes 2 typos in index names and a missing comment change introduced in #385 