### PR TITLE
Fix broken retry mechanics

### DIFF
--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -48,10 +48,6 @@ func WithBackoff(
 			return
 		}
 
-		if err = parentCtx.Err(); err != nil {
-			return
-		}
-
 		if settings.OnError != nil {
 			settings.OnError(time.Since(start), attempt, err, prevErr)
 		}


### PR DESCRIPTION
dc7511c introduced a parent context check to suppress logging if
it was canceled.
If it was not canceled, the check overwrites the variable err,
which resets every previous real error to nil,
which then leads to fatals because the OnError callback or
the IsRetryable function expect a non-nil error.
Since I cannot reproduce which logs should have been suppressed by
the changes, I removed them completely.