### PR TITLE
Make NotificationRecipient struct readable

### DIFF
--- a/pkg/icingadb/v1/notification.go
+++ b/pkg/icingadb/v1/notification.go
@@ -36,8 +36,11 @@ type NotificationUsergroup struct {
 }
 
 type NotificationRecipient struct {
-	NotificationUser `json:",inline"`
-	UsergroupId      types.Binary `json:"usergroup_id"`
+	EntityWithoutChecksum `json:",inline"`
+	EnvironmentMeta       `json:",inline"`
+	NotificationId        types.Binary `json:"notification_id"`
+	UserId                types.Binary `json:"user_id"`
+	UsergroupId           types.Binary `json:"usergroup_id"`
 }
 
 type NotificationCustomvar struct {


### PR DESCRIPTION
Having `NotificationUser` as part of `NotificationRecipient`, just because they share a few attributes, makes the structure a bit confusing.