### PR TITLE
Docs: Fix foreground command config parameter

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -206,7 +206,7 @@ mysql -u root -p icingadb </usr/share/icingadb/schema/mysql/schema.sql
 Foreground:
 
 ```
-icingadb -config /etc/icingadb/config.yml
+icingadb --config /etc/icingadb/config.yml
 ```
 
 Systemd service:


### PR DESCRIPTION
Adds a missing `-` to the config parameter of the foreground command.