### PR TITLE
Docs: Replace GRANT + IDENTIFIED BY command incompatible with newer MySQL versions

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -192,7 +192,8 @@ Set up a MySQL database for Icinga DB:
 # mysql -u root -p
 
 CREATE DATABASE icingadb;
-GRANT ALL ON icingadb.* TO 'icingadb'@'127.0.0.1' IDENTIFIED BY 'icingadb';
+CREATE USER 'icingadb'@'127.0.0.1' IDENTIFIED BY 'icingadb';
+GRANT ALL ON icingadb.* TO 'icingadb'@'127.0.0.1';
 ```
 
 After creating the database, you can import the Icinga DB schema using the following command:


### PR DESCRIPTION
Newer MySQL versions (8+) no longer allow using the `GRANT + IDENTIFIED BY` shortcut for creating a user and granting rights at the same time. By splitting this command into `CREATE USER` and `GRANT` we make sure to support old and new versions.