### PR TITLE
Integration tests: skip intermittently failing test

### DIFF
--- a/tests/history_test.go
+++ b/tests/history_test.go
@@ -287,6 +287,11 @@ func testHistory(t *testing.T, numNodes int) {
 			assertEventuallyDrained(t, n.RedisClient, "icinga:history:stream:downtime")
 		}
 
+		if numNodes > 1 {
+			t.Skip("does not work reliably at the moment due to a problem in icinga2: " +
+				"https://github.com/Icinga/icinga2/issues/9101")
+		}
+
 		eventually.Assert(t, func(t require.TestingT) {
 			var rows []string
 			err = db.Select(&rows, "SELECT h.event_type FROM history h"+


### PR DESCRIPTION
The test fails depending on the order in which both Icinga DB instances process history events and is due to an issue in Icinga 2 documented at https://github.com/Icinga/icinga2/issues/9101.