### PR TITLE
Integration tests: test that both icinga2 instances write identical history streams

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/containerd v1.5.6 // indirect
 	github.com/go-redis/redis/v8 v8.11.3
 	github.com/google/uuid v1.3.0
-	github.com/icinga/icinga-testing v0.0.0-20211112112017-64c69fdac3ca
+	github.com/icinga/icinga-testing v0.0.0-20211203084126-748428acf86d
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.19.1

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -392,6 +392,10 @@ github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpO
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/icinga/icinga-testing v0.0.0-20211112112017-64c69fdac3ca h1:8EXQTKEqUkmF/9/9iIQNPKT0BF2AY9/zunbpcRx+fcI=
 github.com/icinga/icinga-testing v0.0.0-20211112112017-64c69fdac3ca/go.mod h1:VzB7xVUPFvAUgX1nDrheKHpQddvUIN24Sei4mLGelpo=
+github.com/icinga/icinga-testing v0.0.0-20211202132752-03a8b5369d7a h1:FoaQd9W/hmnJ5V63dbKE6M8WBmkyhptR16Xp5WXzLko=
+github.com/icinga/icinga-testing v0.0.0-20211202132752-03a8b5369d7a/go.mod h1:VzB7xVUPFvAUgX1nDrheKHpQddvUIN24Sei4mLGelpo=
+github.com/icinga/icinga-testing v0.0.0-20211203084126-748428acf86d h1:NDqQPFq81quN4fYRmpK53wz1Jx1Pik7IBT0KoxMMsag=
+github.com/icinga/icinga-testing v0.0.0-20211203084126-748428acf86d/go.mod h1:VzB7xVUPFvAUgX1nDrheKHpQddvUIN24Sei4mLGelpo=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/tests/history_test.go
+++ b/tests/history_test.go
@@ -312,6 +312,7 @@ func testHistory(t *testing.T, numNodes int) {
 
 		req, err = json.Marshal(ActionsRemoveDowntimeRequest{
 			Downtime: downtimeName,
+			Author:   utils.RandomString(8),
 		})
 		require.NoError(t, err, "marshal remove-downtime request")
 		response, err = client.PostJson("/v1/actions/remove-downtime", bytes.NewBuffer(req))
@@ -678,6 +679,7 @@ type ActionsProcessCheckResultRequest struct {
 
 type ActionsRemoveDowntimeRequest struct {
 	Downtime string `json:"downtime"`
+	Author   string `json:"author"`
 }
 
 type ActionsScheduleDowntimeRequest struct {


### PR DESCRIPTION
Tests for the following two PRs that extend the history integration tests so that they check if both icinga2 instances in a HA setup write identical history streams. Should only be merged after these are merged to prevent failing tests (d'oh!).

### Blocked by
* https://github.com/Icinga/icinga2/pull/9112
* https://github.com/Icinga/icinga2/pull/9122

refs https://github.com/Icinga/icinga2/issues/9101