### PR TITLE
Make sure Redis connection pool is large enough

### DIFF
--- a/pkg/config/redis.go
+++ b/pkg/config/redis.go
@@ -8,6 +8,7 @@ import (
 	"github.com/icinga/icingadb/pkg/icingaredis"
 	"github.com/icinga/icingadb/pkg/logging"
 	"github.com/icinga/icingadb/pkg/retry"
+	"github.com/icinga/icingadb/pkg/utils"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"net"
@@ -54,6 +55,7 @@ func (r *Redis) NewClient(logger *logging.Logger) (*icingaredis.Client, error) {
 
 	opts := c.Options()
 	opts.MaxRetries = opts.PoolSize + 1 // https://github.com/go-redis/redis/issues/1737
+	opts.PoolSize = utils.MaxInt(32, opts.PoolSize)
 	c = redis.NewClient(opts)
 
 	return icingaredis.NewClient(c, logger, &r.Options), nil

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -191,3 +191,12 @@ func AppName() string {
 
 	return filepath.Base(exe)
 }
+
+// MaxInt returns the larger of the given integers.
+func MaxInt(x, y int) int {
+	if x > y {
+		return x
+	}
+
+	return y
+}


### PR DESCRIPTION
The default Redis `PoolSize` is `10 * CPU`, which isn't enough to run Icinga DB on machines with only 1 CPU.

Most of our open connections come from blocking XREADs. (e.g. Heartbeat, Runtime, Overdue, History)

fixes #425 