### PR TITLE
Run daily integration tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -5,6 +5,8 @@ on:
     branches:
       - master
   pull_request: {}
+  schedule:
+    - cron: '57 3 * * *'
 
 jobs:
   integration-tests:


### PR DESCRIPTION
As those also implicitly test code in the icinga2 repo, it makes sense to run them periodically to notice if we break something over there.

(Some time at night was chosen by a fair dice roll.)