### PR TITLE
Fix currently not able to enable TLS

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,7 +83,7 @@ func ParseFlags() (*Flags, error) {
 
 // TLS provides TLS configuration options for Redis and Database.
 type TLS struct {
-	Tls      bool   `yaml:"tls"`
+	Enable   bool   `yaml:"tls"`
 	Cert     string `yaml:"cert"`
 	Key      string `yaml:"key"`
 	Ca       string `yaml:"ca"`
@@ -92,7 +92,7 @@ type TLS struct {
 
 // MakeConfig assembles a tls.Config from t and address.
 func (t *TLS) MakeConfig(address string) (*tls.Config, error) {
-	if !t.Tls {
+	if !t.Enable {
 		return nil, nil
 	}
 

--- a/pkg/config/database.go
+++ b/pkg/config/database.go
@@ -19,13 +19,13 @@ var registerDriverOnce sync.Once
 
 // Database defines database client configuration.
 type Database struct {
-	Host     string `yaml:"host"`
-	Port     int    `yaml:"port"`
-	Database string `yaml:"database"`
-	User     string `yaml:"user"`
-	Password string `yaml:"password"`
-	TLS      `yaml:",inline"`
-	Options  icingadb.Options `yaml:"options"`
+	Host       string           `yaml:"host"`
+	Port       int              `yaml:"port"`
+	Database   string           `yaml:"database"`
+	User       string           `yaml:"user"`
+	Password   string           `yaml:"password"`
+	TlsOptions TLS              `yaml:",inline"`
+	Options    icingadb.Options `yaml:"options"`
 }
 
 // Open prepares the DSN string and driver configuration,
@@ -44,7 +44,7 @@ func (d *Database) Open(logger *logging.Logger) (*icingadb.DB, error) {
 	config.DBName = d.Database
 	config.Timeout = time.Minute
 
-	tlsConfig, err := d.TLS.MakeConfig(config.Addr)
+	tlsConfig, err := d.TlsOptions.MakeConfig(config.Addr)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/redis.go
+++ b/pkg/config/redis.go
@@ -19,10 +19,10 @@ import (
 
 // Redis defines Redis client configuration.
 type Redis struct {
-	Address  string `yaml:"address"`
-	Password string `yaml:"password"`
-	TLS      `yaml:",inline"`
-	Options  icingaredis.Options `yaml:"options"`
+	Address    string              `yaml:"address"`
+	Password   string              `yaml:"password"`
+	TlsOptions TLS                 `yaml:",inline"`
+	Options    icingaredis.Options `yaml:"options"`
 }
 
 type ctxDialerFunc = func(ctx context.Context, network, addr string) (net.Conn, error)
@@ -30,7 +30,7 @@ type ctxDialerFunc = func(ctx context.Context, network, addr string) (net.Conn, 
 // NewClient prepares Redis client configuration,
 // calls redis.NewClient, but returns *icingaredis.Client.
 func (r *Redis) NewClient(logger *logging.Logger) (*icingaredis.Client, error) {
-	tlsConfig, err := r.TLS.MakeConfig(r.Address)
+	tlsConfig, err := r.TlsOptions.MakeConfig(r.Address)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When embedding `TLS`, the field name is implicitly specified as `TLS`, which conflicts with the YAML key `tls`, which currently does not allow TLS to be enabled. I'm not entirely sure if this is a bug in goccy/go-yaml, but if a struct field name other than TLS is specified, the configuration works again.