### PR TITLE
doc: Document the password option for Redis

### DIFF
--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -12,6 +12,7 @@ Configuration of the Redis that Icinga writes to.
 Option                   | Description
 -------------------------|-----------------------------------------------
 address                  | **Required.** Redis host:port address.
+password                 | **Optional.** The password to use.
 tls                      | **Optional.** Whether to use TLS.
 cert                     | **Optional.** Path to TLS client certificate.
 key                      | **Optional.** Path to TLS private key.


### PR DESCRIPTION
Adds the `password` option to the description of how the Redis connection can be configured.