### PR TITLE
Fix intermittent test failures

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/containerd/containerd v1.5.6 // indirect
 	github.com/go-redis/redis/v8 v8.11.3
 	github.com/google/uuid v1.3.0
-	github.com/icinga/icinga-testing v0.0.0-20211203084126-748428acf86d
+	github.com/icinga/icinga-testing v0.0.0-20220309154907-12cf833da4f3
 	github.com/jmoiron/sqlx v1.3.4
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.19.1

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -390,12 +390,8 @@ github.com/hashicorp/golang-lru v0.5.1/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/icinga/icinga-testing v0.0.0-20211112112017-64c69fdac3ca h1:8EXQTKEqUkmF/9/9iIQNPKT0BF2AY9/zunbpcRx+fcI=
-github.com/icinga/icinga-testing v0.0.0-20211112112017-64c69fdac3ca/go.mod h1:VzB7xVUPFvAUgX1nDrheKHpQddvUIN24Sei4mLGelpo=
-github.com/icinga/icinga-testing v0.0.0-20211202132752-03a8b5369d7a h1:FoaQd9W/hmnJ5V63dbKE6M8WBmkyhptR16Xp5WXzLko=
-github.com/icinga/icinga-testing v0.0.0-20211202132752-03a8b5369d7a/go.mod h1:VzB7xVUPFvAUgX1nDrheKHpQddvUIN24Sei4mLGelpo=
-github.com/icinga/icinga-testing v0.0.0-20211203084126-748428acf86d h1:NDqQPFq81quN4fYRmpK53wz1Jx1Pik7IBT0KoxMMsag=
-github.com/icinga/icinga-testing v0.0.0-20211203084126-748428acf86d/go.mod h1:VzB7xVUPFvAUgX1nDrheKHpQddvUIN24Sei4mLGelpo=
+github.com/icinga/icinga-testing v0.0.0-20220309154907-12cf833da4f3 h1:w+d7+9iXWr06sNi9p2gwKhRqLU77FdpNmFm9DVsWbl0=
+github.com/icinga/icinga-testing v0.0.0-20220309154907-12cf833da4f3/go.mod h1:VzB7xVUPFvAUgX1nDrheKHpQddvUIN24Sei4mLGelpo=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/tests/history_test.go
+++ b/tests/history_test.go
@@ -150,8 +150,6 @@ func testHistory(t *testing.T, numNodes int) {
 	client := nodes[0].IcingaClient
 
 	t.Run("Acknowledgement", func(t *testing.T) {
-		t.Parallel()
-
 		const stream = "icinga:history:stream:acknowledgement"
 
 		hostname := utils.UniqueName(t, "host")
@@ -213,8 +211,6 @@ func testHistory(t *testing.T, numNodes int) {
 	})
 
 	t.Run("Comment", func(t *testing.T) {
-		t.Parallel()
-
 		const stream = "icinga:history:stream:comment"
 
 		type HistoryEvent struct {
@@ -323,8 +319,6 @@ func testHistory(t *testing.T, numNodes int) {
 	})
 
 	t.Run("Downtime", func(t *testing.T) {
-		t.Parallel()
-
 		const stream = "icinga:history:stream:downtime"
 
 		type HistoryEvent struct {
@@ -457,8 +451,6 @@ func testHistory(t *testing.T, numNodes int) {
 	})
 
 	t.Run("Flapping", func(t *testing.T) {
-		t.Parallel()
-
 		const stream = "icinga:history:stream:flapping"
 
 		hostname := utils.UniqueName(t, "host")
@@ -504,8 +496,6 @@ func testHistory(t *testing.T, numNodes int) {
 	})
 
 	t.Run("Notification", func(t *testing.T) {
-		t.Parallel()
-
 		const stream = "icinga:history:stream:notification"
 
 		hostname := utils.UniqueName(t, "host")
@@ -584,8 +574,6 @@ func testHistory(t *testing.T, numNodes int) {
 	})
 
 	t.Run("State", func(t *testing.T) {
-		t.Parallel()
-
 		const stream = "icinga:history:stream:state"
 
 		hostname := utils.UniqueName(t, "host")


### PR DESCRIPTION
This PR fixes two causes of intermittent test failures:

1. In the TestHistory/HA test case, both nodes were started with the default `/etc/icinga2/conf.d/*.conf` still in place. This leads to an inconsistent configuration on both nodes which is doomed to write inconsistent history at some point. This will be fixed by https://github.com/Icinga/icinga-testing/pull/15 and this PR bumps the version of icinga-testing.
2. Running the sub-tests of TestHistory/HA in parallel can result in a situation where some history stream is checked for consistency while another sub-test is still running and generating events that also affect that stream (for example, the downtime test may generate notification, the notification test may generate state changes, ...) that are only processed by one of the nodes so far. Therefore remove the parallelism altogether from that test case. The runtime is dominated by the downtime test anyways.

### Blocked by
* https://github.com/Icinga/icinga-testing/pull/15

### Todo
* [x] After merging above PR, update this PR to use the merge commit

fixes #433