### PR TITLE
Schema: Make custom variable names case insensitive

### DIFF
--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -809,7 +809,7 @@ CREATE TABLE customvar (
   environment_id binary(20) NOT NULL COMMENT 'environment.id',
   name_checksum binary(20) NOT NULL COMMENT 'sha1(name)',
 
-  name varchar(255) NOT NULL,
+  name varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
   value text NOT NULL,
 
   PRIMARY KEY (id)
@@ -821,7 +821,7 @@ CREATE TABLE customvar_flat (
   customvar_id binary(20) NOT NULL COMMENT 'sha1(customvar.id)',
   flatname_checksum binary(20) NOT NULL COMMENT 'sha1(flatname after conversion)',
 
-  flatname varchar(512) NOT NULL COMMENT 'Path converted with `.` and `[ ]`',
+  flatname varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Path converted with `.` and `[ ]`',
   flatvalue text NOT NULL,
 
   PRIMARY KEY (id),

--- a/schema/mysql/upgrades/1.0.0.sql
+++ b/schema/mysql/upgrades/1.0.0.sql
@@ -41,5 +41,11 @@ ALTER TABLE notes_url
   MODIFY id binary(20) NOT NULL COMMENT 'sha1(environment.id + notes_url)',
   ADD PRIMARY KEY (id);
 
+ALTER TABLE customvar
+  MODIFY name varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL;
+
+ALTER TABLE customvar_flat
+  MODIFY flatname varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Path converted with `.` and `[ ]`';
+
 INSERT INTO icingadb_schema (version, TIMESTAMP)
   VALUES (3, CURRENT_TIMESTAMP() * 1000);

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -1370,7 +1370,7 @@ CREATE TABLE customvar (
   environment_id bytea20 NOT NULL,
   name_checksum bytea20 NOT NULL,
 
-  name varchar(255) NOT NULL,
+  name citext NOT NULL,
   value text NOT NULL,
 
   CONSTRAINT pk_customvar PRIMARY KEY (id)
@@ -1390,7 +1390,7 @@ CREATE TABLE customvar_flat (
   customvar_id bytea20 NOT NULL,
   flatname_checksum bytea20 NOT NULL,
 
-  flatname varchar(512) NOT NULL,
+  flatname citext NOT NULL,
   flatvalue text NOT NULL,
 
   CONSTRAINT pk_customvar_flat PRIMARY KEY (id)


### PR DESCRIPTION
To make custom variable searches case-insensitive by default.

fixes #443