### PR TITLE
Remove obsolete comment

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: '^1.16' # icinga-testing uses go:embed which is available in Go 1.16+
+          go-version: '^1.16'
       - name: Build Icinga DB
         run: go build ./cmd/icingadb
         env:


### PR DESCRIPTION
That Go version doesn’t differ from the mainly used one.