### PR TITLE
PostgreSQL: Support LIKE for integer/enum columns

### DIFF
--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -161,6 +161,24 @@ BEGIN
 END;
 $$;
 
+/* At the moment Icinga DB Web doesn't know the column types,
+   so it sends SQL queries with LIKE operators for all suggestions in the search bar,
+   which fails for numeric and enum types on PostgreSQL.
+   To support this, the LIKE operator (internally translated to ~~) is overloaded.
+   Note that this is only a temporary solution until Icinga DB Web provides column type support.
+ */
+CREATE OR REPLACE FUNCTION anynonarrayliketext(anynonarray, text)
+  RETURNS bool
+  LANGUAGE plpgsql
+  IMMUTABLE
+  PARALLEL SAFE
+  AS $$
+    BEGIN
+      RETURN $1::TEXT LIKE $2;
+    END;
+  $$;
+CREATE OPERATOR ~~ (LEFTARG=anynonarray, RIGHTARG=text, PROCEDURE=anynonarrayliketext);
+
 CREATE TABLE host (
   id bytea20 NOT NULL,
   environment_id bytea20 NOT NULL,


### PR DESCRIPTION
At the moment Icinga DB Web doesn't know the column types, so it sends
SQL queries with LIKE operators for all suggestions in the search bar,
which fails for numeric and enum types on PostgreSQL. To support this,
the LIKE operator (internally translated to ~~) is overloaded. Note
that this is only a temporary solution until Icinga DB Web provides
column type support.