### PR TITLE
Retry EAGAIN

### DIFF
--- a/pkg/config/redis.go
+++ b/pkg/config/redis.go
@@ -74,7 +74,7 @@ func dialWithLogging(dialer ctxDialerFunc, logger *logging.Logger) ctxDialerFunc
 			func(err error) bool {
 				if op, ok := err.(*net.OpError); ok {
 					sys, ok := op.Err.(*os.SyscallError)
-					return ok && sys.Err == syscall.ECONNREFUSED
+					return ok && (sys.Err == syscall.ECONNREFUSED || sys.Err == syscall.EAGAIN)
 				}
 				return false
 			},

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -102,7 +102,7 @@ func (log mysqlLogger) Print(v ...interface{}) {
 }
 
 func shouldRetry(err error) bool {
-	if errors.Is(err, driver.ErrBadConn) || errors.Is(err, syscall.ECONNREFUSED) {
+	if errors.Is(err, driver.ErrBadConn) || errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.EAGAIN) {
 		return true
 	}
 


### PR DESCRIPTION
I noticed that EAGAIN isn't retried even though that's by definition an error where you should retry.

## Test

That error happens for me most of the time when using socat to proxy Redis like that:
```
socat -dd UNIX-LISTEN:$XDG_RUNTIME_DIR/redis.sock,reuseaddr,fork TCP:redis.example.invalid:6379
```

### Before

```
2022-05-03T14:28:42.456+0200	WARN	redis	Can't connect to Redis. Retrying	{"error": "dial unix /run/user/1000/redis.sock: connect: resource temporarily unavailable"}
2022-05-03T14:28:42.457+0200	WARN	redis	Can't connect to Redis. Retrying	{"error": "dial unix /run/user/1000/redis.sock: connect: resource temporarily unavailable"}
2022-05-03T14:28:42.457+0200	WARN	redis	Can't connect to Redis. Retrying	{"error": "dial unix /run/user/1000/redis.sock: connect: resource temporarily unavailable"}
2022-05-03T14:28:42.457+0200	WARN	redis	Can't connect to Redis. Retrying	{"error": "dial unix /run/user/1000/redis.sock: connect: resource temporarily unavailable"}
2022-05-03T14:28:42.458+0200	WARN	redis	Can't connect to Redis. Retrying	{"error": "dial unix /run/user/1000/redis.sock: connect: resource temporarily unavailable"}
2022-05-03T14:28:42.459+0200	WARN	redis	Can't connect to Redis. Retrying	{"error": "dial unix /run/user/1000/redis.sock: connect: resource temporarily unavailable"}
2022-05-03T14:28:42.459+0200	WARN	redis	Can't connect to Redis. Retrying	{"error": "dial unix /run/user/1000/redis.sock: operation was canceled"}
2022-05-03T14:28:42.463+0200	FATAL	icingadb	dial unix /run/user/1000/redis.sock: connect: resource temporarily unavailable
can't retry
```

Process subsequently exits.

### After

```
2022-05-03T14:29:54.458+0200	WARN	redis	Can't connect to Redis. Retrying	{"error": "dial unix /run/user/1000/redis.sock: connect: resource temporarily unavailable"}
2022-05-03T14:29:54.458+0200	WARN	redis	Can't connect to Redis. Retrying	{"error": "dial unix /run/user/1000/redis.sock: connect: resource temporarily unavailable"}
2022-05-03T14:29:54.458+0200	WARN	redis	Can't connect to Redis. Retrying	{"error": "dial unix /run/user/1000/redis.sock: connect: resource temporarily unavailable"}
2022-05-03T14:29:54.459+0200	INFO	redis	Reconnected to Redis	{"after": "989.889µs", "attempts": 2}
2022-05-03T14:29:54.458+0200	WARN	redis	Can't connect to Redis. Retrying	{"error": "dial unix /run/user/1000/redis.sock: connect: resource temporarily unavailable"}
2022-05-03T14:29:54.461+0200	INFO	redis	Reconnected to Redis	{"after": "2.586539ms", "attempts": 2}
2022-05-03T14:29:54.500+0200	INFO	redis	Reconnected to Redis	{"after": "41.271871ms", "attempts": 2}
2022-05-03T14:29:54.500+0200	INFO	redis	Reconnected to Redis	{"after": "41.846137ms", "attempts": 2}
```

Process keeps running.