### PR TITLE
Retention: take environment_id into account

### DIFF
--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -1836,11 +1836,15 @@ ALTER TABLE state_history ALTER COLUMN endpoint_id SET STORAGE PLAIN;
 ALTER TABLE state_history ALTER COLUMN host_id SET STORAGE PLAIN;
 ALTER TABLE state_history ALTER COLUMN service_id SET STORAGE PLAIN;
 
+CREATE INDEX idx_state_history_event_time ON state_history(event_time);
+
 COMMENT ON COLUMN state_history.id IS 'sha1(environment.name + host|service.name + event_time)';
 COMMENT ON COLUMN state_history.environment_id IS 'environment.id';
 COMMENT ON COLUMN state_history.endpoint_id IS 'endpoint.id';
 COMMENT ON COLUMN state_history.host_id IS 'host.id';
 COMMENT ON COLUMN state_history.service_id IS 'service.id';
+
+COMMENT ON INDEX idx_state_history_event_time IS 'Filter for history retention';
 
 CREATE TABLE downtime_history (
   downtime_id bytea20 NOT NULL,
@@ -1878,6 +1882,8 @@ ALTER TABLE downtime_history ALTER COLUMN parent_id SET STORAGE PLAIN;
 ALTER TABLE downtime_history ALTER COLUMN host_id SET STORAGE PLAIN;
 ALTER TABLE downtime_history ALTER COLUMN service_id SET STORAGE PLAIN;
 
+CREATE INDEX idx_downtime_history_end_time ON downtime_history(end_time);
+
 COMMENT ON COLUMN downtime_history.downtime_id IS 'downtime.id';
 COMMENT ON COLUMN downtime_history.environment_id IS 'environment.id';
 COMMENT ON COLUMN downtime_history.endpoint_id IS 'endpoint.id';
@@ -1888,6 +1894,8 @@ COMMENT ON COLUMN downtime_history.service_id IS 'service.id';
 COMMENT ON COLUMN downtime_history.start_time IS 'Time when the host went into a problem state during the downtimes timeframe';
 COMMENT ON COLUMN downtime_history.end_time IS 'Problem state assumed: scheduled_end_time if fixed, start_time + duration otherwise';
 COMMENT ON COLUMN downtime_history.scheduled_by IS 'Name of the ScheduledDowntime which created this Downtime. 255+1+255+1+255, i.e. "host.name!service.name!scheduled-downtime-name"';
+
+COMMENT ON INDEX idx_downtime_history_end_time IS 'Filter for history retention';
 
 CREATE TABLE comment_history (
   comment_id bytea20 NOT NULL,
@@ -1917,11 +1925,15 @@ ALTER TABLE comment_history ALTER COLUMN endpoint_id SET STORAGE PLAIN;
 ALTER TABLE comment_history ALTER COLUMN host_id SET STORAGE PLAIN;
 ALTER TABLE comment_history ALTER COLUMN service_id SET STORAGE PLAIN;
 
+CREATE INDEX idx_comment_history_remove_time ON comment_history(remove_time);
+
 COMMENT ON COLUMN comment_history.comment_id IS 'comment.id';
 COMMENT ON COLUMN comment_history.environment_id IS 'environment.id';
 COMMENT ON COLUMN comment_history.endpoint_id IS 'endpoint.id';
 COMMENT ON COLUMN comment_history.host_id IS 'host.id';
 COMMENT ON COLUMN comment_history.service_id IS 'service.id';
+
+COMMENT ON INDEX idx_comment_history_remove_time IS 'Filter for history retention';
 
 CREATE TABLE flapping_history (
   id bytea20 NOT NULL,
@@ -1947,11 +1959,15 @@ ALTER TABLE flapping_history ALTER COLUMN endpoint_id SET STORAGE PLAIN;
 ALTER TABLE flapping_history ALTER COLUMN host_id SET STORAGE PLAIN;
 ALTER TABLE flapping_history ALTER COLUMN service_id SET STORAGE PLAIN;
 
+CREATE INDEX idx_flapping_history_end_time ON flapping_history(end_time);
+
 COMMENT ON COLUMN flapping_history.id IS 'sha1(environment.id + "Host"|"Service" + host|service.name + start_time)';
 COMMENT ON COLUMN flapping_history.environment_id IS 'environment.id';
 COMMENT ON COLUMN flapping_history.endpoint_id IS 'endpoint.id';
 COMMENT ON COLUMN flapping_history.host_id IS 'host.id';
 COMMENT ON COLUMN flapping_history.service_id IS 'service.id';
+
+COMMENT ON INDEX idx_flapping_history_end_time IS 'Filter for history retention';
 
 CREATE TABLE acknowledgement_history (
   id bytea20 NOT NULL,
@@ -1979,6 +1995,8 @@ ALTER TABLE acknowledgement_history ALTER COLUMN endpoint_id SET STORAGE PLAIN;
 ALTER TABLE acknowledgement_history ALTER COLUMN host_id SET STORAGE PLAIN;
 ALTER TABLE acknowledgement_history ALTER COLUMN service_id SET STORAGE PLAIN;
 
+CREATE INDEX idx_acknowledgement_history_clear_time ON acknowledgement_history(clear_time);
+
 COMMENT ON COLUMN acknowledgement_history.id IS 'sha1(environment.id + "Host"|"Service" + host|service.name + set_time)';
 COMMENT ON COLUMN acknowledgement_history.environment_id IS 'environment.id';
 COMMENT ON COLUMN acknowledgement_history.endpoint_id IS 'endpoint.id';
@@ -1988,6 +2006,8 @@ COMMENT ON COLUMN acknowledgement_history.author IS 'NULL if ack_set event happe
 COMMENT ON COLUMN acknowledgement_history.comment IS 'NULL if ack_set event happened before Icinga DB history recording';
 COMMENT ON COLUMN acknowledgement_history.is_sticky IS 'NULL if ack_set event happened before Icinga DB history recording';
 COMMENT ON COLUMN acknowledgement_history.is_persistent IS 'NULL if ack_set event happened before Icinga DB history recording';
+
+COMMENT ON INDEX idx_acknowledgement_history_clear_time IS 'Filter for history retention';
 
 CREATE TABLE history (
   id bytea20 NOT NULL,

--- a/tests/internal/utils/redis.go
+++ b/tests/internal/utils/redis.go
@@ -1,0 +1,37 @@
+package utils
+
+import (
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"github.com/go-redis/redis/v8"
+	"github.com/icinga/icinga-testing/services"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func GetEnvironmentIdFromRedis(t *testing.T, r services.RedisServer) []byte {
+	conn := r.Open()
+	defer conn.Close()
+
+	heartbeat, err := conn.XRead(context.Background(), &redis.XReadArgs{
+		Streams: []string{"icinga:stats", "0"},
+		Count:   1,
+		Block:   10 * time.Second,
+	}).Result()
+	require.NoError(t, err, "reading from icinga:stats failed")
+	require.NotEmpty(t, heartbeat, "response contains no streams")
+	require.NotEmpty(t, heartbeat[0].Messages, "response contains no messages")
+	require.Contains(t, heartbeat[0].Messages[0].Values, "icingadb_environment",
+		"icinga:stats message misses icingadb_environment")
+
+	var envIdHex string
+	err = json.Unmarshal([]byte(heartbeat[0].Messages[0].Values["icingadb_environment"].(string)), &envIdHex)
+	require.NoError(t, err, "cannot parse environment ID as a JSON string")
+
+	envId, err := hex.DecodeString(envIdHex)
+	require.NoError(t, err, "environment ID is not a hex string")
+
+	return envId
+}


### PR DESCRIPTION
This PR ensures that the retention feature only deletes history from the current environment. Previously, the deletion queries where missing an appropriate WHERE clause.

Also adds missing indices to the PostgreSQL schema. With this PR:
```console
$ diff -us <(grep -o 'idx_\w*' schema/mysql/schema.sql | sort -u) <(grep -o 'idx_\w*' schema/pgsql/schema.sql | sort -u)
Files /proc/self/fd/11 and /proc/self/fd/12 are identical
```

Indices are kept without the environment ID for now as icingadb-web currently does not support multiple environments so that feature is of limited use at the moment anyways and there will almost certainly be only one environment in the database. So adding the environment ID would only make the indices bigger until then and in one case would even require duplicating the index as icingadb-web needs it without the environment ID at the moment. It's quite possible that when icingadb-web gets multi-env support, it might need the index with the environment ID then as well. Once it gets there, one has to reevaluate all these indices anyways.

## Tests

See changes to the included tests.

## Blocked by
* #247: That PR also touches retention, so changes here would only introduce merge conflicts anyways. As SLA reporting should be mostly done now, I'd want to avoid having to delay it due to having to resolve merge conflicts.

closes #468