### PR TITLE
Check for required database and Redis config options during config validation

### DIFF
--- a/pkg/config/database.go
+++ b/pkg/config/database.go
@@ -47,7 +47,7 @@ func (d *Database) Open(logger *logging.Logger) (*icingadb.DB, error) {
 		config.User = d.User
 		config.Passwd = d.Password
 
-		if strings.HasPrefix(d.Host, "/") {
+		if d.isUnixAddr() {
 			config.Net = "unix"
 			config.Addr = d.Host
 		} else {
@@ -151,7 +151,23 @@ func (d *Database) Validate() error {
 		return unknownDbType(d.Type)
 	}
 
+	if d.Host == "" {
+		return errors.New("database host missing")
+	}
+
+	if d.User == "" {
+		return errors.New("database user missing")
+	}
+
+	if d.Database == "" {
+		return errors.New("database name missing")
+	}
+
 	return d.Options.Validate()
+}
+
+func (d *Database) isUnixAddr() bool {
+	return strings.HasPrefix(d.Host, "/")
 }
 
 func unknownDbType(t string) error {

--- a/pkg/config/redis.go
+++ b/pkg/config/redis.go
@@ -103,5 +103,9 @@ func dialWithLogging(dialer ctxDialerFunc, logger *logging.Logger) ctxDialerFunc
 
 // Validate checks constraints in the supplied Redis configuration and returns an error if they are violated.
 func (r *Redis) Validate() error {
+	if r.Address == "" {
+		return errors.New("Redis address missing")
+	}
+
 	return r.Options.Validate()
 }


### PR DESCRIPTION
## Tests

Starting Icinga DB with an empty config.

### Before

Tries to start, fails to connect, goes into retry mode, and finally fails with a long stack trace (see #472 for full output).

### After

```console
$ go run ./cmd/icingadb -c <(printf '{}')
panic: invalid configuration: database host must be specified

goroutine 1 [running]:
github.com/icinga/icingadb/pkg/utils.Fatal(...)
	/home/jbrost/dev/icingadb/pkg/utils/utils.go:114
github.com/icinga/icingadb/internal/command.New()
	/home/jbrost/dev/icingadb/internal/command/command.go:41 +0x185
main.run()
	/home/jbrost/dev/icingadb/cmd/icingadb/main.go:40 +0x57
main.main()
	/home/jbrost/dev/icingadb/cmd/icingadb/main.go:36 +0x19
exit status 2
```

fixes #472