### PR TITLE
Don't print a stacktrace on config errors

### DIFF
--- a/internal/command/command.go
+++ b/internal/command/command.go
@@ -7,7 +7,6 @@ import (
 	"github.com/icinga/icingadb/pkg/icingadb"
 	"github.com/icinga/icingadb/pkg/icingaredis"
 	"github.com/icinga/icingadb/pkg/logging"
-	"github.com/icinga/icingadb/pkg/utils"
 	goflags "github.com/jessevdk/go-flags"
 	"github.com/pkg/errors"
 	"os"
@@ -38,7 +37,8 @@ func New() *Command {
 
 	cfg, err := config.FromYAMLFile(flags.Config)
 	if err != nil {
-		utils.Fatal(err)
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
 	}
 
 	return &Command{


### PR DESCRIPTION
Throwing a stacktrace at a user isn't the nicest thing to do (looks more like the application did something wrong rather than the user did something wrong).

Exit code 2 seems to be what go does when you panic it, but invalid config is somewhat similar to invalid cli options (which also uses exit code 2 at the moment), so I kept that one.

## Tests

### Before
```
go run ./cmd/icingadb -c <(printf '{database: {type: invalid}}')
panic: invalid configuration: unknown database type "invalid", must be one of: "mysql", "pgsql"

goroutine 1 [running]:
github.com/icinga/icingadb/pkg/utils.Fatal(...)
	/home/jbrost/dev/icingadb/pkg/utils/utils.go:114
github.com/icinga/icingadb/internal/command.New()
	/home/jbrost/dev/icingadb/internal/command/command.go:41 +0x185
main.run()
	/home/jbrost/dev/icingadb/cmd/icingadb/main.go:40 +0x57
main.main()
	/home/jbrost/dev/icingadb/cmd/icingadb/main.go:36 +0x19
exit status 2
```

### After

```
$ go run ./cmd/icingadb -c <(printf '{database: {type: invalid}}')
invalid configuration: unknown database type "invalid", must be one of: "mysql", "pgsql"
exit status 2
```