### PR TITLE
Retention: periodically log number of items removed

### DIFF
--- a/pkg/icingadb/history/retention.go
+++ b/pkg/icingadb/history/retention.go
@@ -129,6 +129,10 @@ func (r *Retention) StartWithCallback(ctx context.Context, c func(table string, 
 				return
 			}
 
+			if rs.Count > 0 {
+				r.logger.Infof("Removed %d old %s history items", rs.Count, category)
+			}
+
 			if c != nil {
 				c(stmt.Table, rs)
 			}


### PR DESCRIPTION
Other components log this information periodically at level info, whereas the retention feature was completely quiet at that level. It's logged at the interval the retention cleanup is run rather than the global configured logging interval since retention cleanup is done less often.

## Tests

### Before

Nothing logged at level info.

### After

```
2022-05-11T09:30:08.862+0200	INFO	history-retention	Removed 5 old state history items
```