### PR TITLE
Retention: remove leftover code from older tests

### DIFF
--- a/pkg/icingadb/history/retention.go
+++ b/pkg/icingadb/history/retention.go
@@ -142,11 +142,6 @@ func NewRetention(
 
 // Start starts the retention.
 func (r *Retention) Start(ctx context.Context) error {
-	return r.StartWithCallback(ctx, nil)
-}
-
-// StartWithCallback starts retention and executes the specified callback each time a retention run completes.
-func (r *Retention) StartWithCallback(ctx context.Context, c func(table string, rs icingadb.CleanupResult)) error {
 	ctx, cancelCtx := context.WithCancel(ctx)
 	defer cancelCtx()
 
@@ -196,10 +191,6 @@ func (r *Retention) StartWithCallback(ctx context.Context, c func(table string, 
 
 			if rs.Count > 0 {
 				r.logger.Infof("Removed %d old %s history items", rs.Count, stmt.Category)
-			}
-
-			if c != nil {
-				c(stmt.Table, rs)
 			}
 		}, periodic.Immediate())
 	}

--- a/pkg/icingadb/history/retention.go
+++ b/pkg/icingadb/history/retention.go
@@ -195,7 +195,7 @@ func (r *Retention) StartWithCallback(ctx context.Context, c func(table string, 
 			}
 
 			if rs.Count > 0 {
-				r.logger.Infof("Removed %d old %s history items", rs.Count, category)
+				r.logger.Infof("Removed %d old %s history items", rs.Count, stmt.Category)
 			}
 
 			if c != nil {

--- a/pkg/icingadb/history/retention.go
+++ b/pkg/icingadb/history/retention.go
@@ -179,7 +179,7 @@ func (r *Retention) Start(ctx context.Context) error {
 			r.logger.Debugf("Cleaning up historical data for category %s from table %s older than %s",
 				stmt.Category, stmt.Table, olderThan)
 
-			rs, err := r.db.CleanupOlderThan(ctx, stmt.CleanupStmt, r.count, olderThan)
+			deleted, err := r.db.CleanupOlderThan(ctx, stmt.CleanupStmt, r.count, olderThan)
 			if err != nil {
 				select {
 				case errs <- err:
@@ -189,8 +189,8 @@ func (r *Retention) Start(ctx context.Context) error {
 				return
 			}
 
-			if rs.Count > 0 {
-				r.logger.Infof("Removed %d old %s history items", rs.Count, stmt.Category)
+			if deleted > 0 {
+				r.logger.Infof("Removed %d old %s history items", deleted, stmt.Category)
 			}
 		}, periodic.Immediate())
 	}


### PR DESCRIPTION
This was added for the tests but the corresponding test was rewritten in #467 so it's no longer used or needed.

Also includes a small build fix for a conflict between #247 and #480 (I basically noticed the conflict while working on this PR before GitHub even sent me a mail for the failing actions, so I just fixed it here).

## Blocked by
* #480: not really a functional dependency, but otherwise I'd remove the unused `rs` here just to add it again in the other PR.