### PR TITLE
DB: use default ports and allow setting port for PostgreSQL Unix domain sockets

### DIFF
--- a/pkg/config/database.go
+++ b/pkg/config/database.go
@@ -52,7 +52,11 @@ func (d *Database) Open(logger *logging.Logger) (*icingadb.DB, error) {
 			config.Addr = d.Host
 		} else {
 			config.Net = "tcp"
-			config.Addr = net.JoinHostPort(d.Host, fmt.Sprint(d.Port))
+			port := d.Port
+			if port == 0 {
+				port = 3306
+			}
+			config.Addr = net.JoinHostPort(d.Host, fmt.Sprint(port))
 		}
 
 		config.DBName = d.Database


### PR DESCRIPTION
This PR implements two changes:
* PostgreSQL: also add the port number to the connection URI for Unix domain sockets as the port is also used to derive the full socket path (`/run/postgresql/.s.PGSQL.5432` for example).
* Make the `database`: `port` config field optional by using the default port. This is done in the connection code rather than using a `default` struct tag as the defaults are evaluated before the YAML is parsed so the database type is not known yet.

## Tests

### MySQL default
```console
$ go run ./cmd/icingadb -c <(printf '{database: {type: mysql, host: localhost}}')
2022-05-12T16:36:27.500+0200	INFO	icingadb	Starting Icinga DB
2022-05-12T16:36:27.500+0200	INFO	icingadb	Connecting to database
2022-05-12T16:36:27.501+0200	WARN	database	Can't connect to database. Retrying	{"error": "dial tcp [::1]:3306: connect: connection refused"}
^C
```

### MySQL explicit
```console
$ go run ./cmd/icingadb -c <(printf '{database: {type: mysql, host: localhost, port: 1234}}')
2022-05-12T16:39:47.750+0200	INFO	icingadb	Starting Icinga DB
2022-05-12T16:39:47.750+0200	INFO	icingadb	Connecting to database
2022-05-12T16:39:47.752+0200	WARN	database	Can't connect to database. Retrying	{"error": "dial tcp [::1]:1234: connect: connection refused"}
^C
```

### PostgreSQL TCP default
```console
$ go run ./cmd/icingadb -c <(printf '{database: {type: pgsql, host: localhost}}')
2022-05-12T16:36:38.908+0200	INFO	icingadb	Starting Icinga DB
2022-05-12T16:36:38.908+0200	INFO	icingadb	Connecting to database
2022-05-12T16:36:38.909+0200	WARN	database	Can't connect to database. Retrying	{"error": "dial tcp [::1]:5432: connect: connection refused"}
^C
```

### PostgreSQL TCP explicit
```console
$ go run ./cmd/icingadb -c <(printf '{database: {type: pgsql, host: localhost, port: 1234}}')
2022-05-12T16:36:46.122+0200	INFO	icingadb	Starting Icinga DB
2022-05-12T16:36:46.123+0200	INFO	icingadb	Connecting to database
2022-05-12T16:36:46.124+0200	WARN	database	Can't connect to database. Retrying	{"error": "dial tcp [::1]:1234: connect: connection refused"}
^C
```

### PostgreSQL Unix default
```console
$ go run ./cmd/icingadb -c <(printf '{database: {type: pgsql, host: /run/postgresql}}')
2022-05-12T16:36:57.804+0200	INFO	icingadb	Starting Icinga DB
2022-05-12T16:36:57.805+0200	INFO	icingadb	Connecting to database
2022-05-12T16:36:57.805+0200	WARN	database	Can't connect to database. Retrying	{"error": "dial unix /run/postgresql/.s.PGSQL.5432: connect: no such file or directory"}
2022-05-12T16:36:57.805+0200	FATAL	icingadb	dial unix /run/postgresql/.s.PGSQL.5432: connect: no such file or directory
can't retry
[stacktrace omitted]
```

### PostgreSQL Unix explicit
```console
$ go run ./cmd/icingadb -c <(printf '{database: {type: pgsql, host: /run/postgresql, port: 1234}}')
2022-05-12T16:37:18.934+0200	INFO	icingadb	Starting Icinga DB
2022-05-12T16:37:18.934+0200	INFO	icingadb	Connecting to database
2022-05-12T16:37:18.934+0200	WARN	database	Can't connect to database. Retrying	{"error": "dial unix /run/postgresql/.s.PGSQL.1234: connect: no such file or directory"}
2022-05-12T16:37:18.934+0200	FATAL	icingadb	dial unix /run/postgresql/.s.PGSQL.1234: connect: no such file or directory
can't retry
[stacktrace omitted]
```

fixes #476 
fixes #479 