### PR TITLE
Integration tests: use separate artifact names for MySQL/PostgreSQL

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -50,6 +50,6 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@v2
         with:
-          name: debug.log.xz
+          name: ${{ matrix.database.name }}-debug.log.xz
           path: debug.log.xz
           retention-days: 1


### PR DESCRIPTION
If I remember correctly, some time ago you were able to download artifacts from the job page, i.e. there was no issues with two jobs using the same artifact name within one workflow. Now it looks like you can only download the artifacts from the workflow page, so this commit allows you to download both files from there.