### PR TITLE
oneBulk(): terminate once input closed (like the regular bulker)

### DIFF
--- a/pkg/com/bulker.go
+++ b/pkg/com/bulker.go
@@ -162,7 +162,11 @@ func oneBulk[T any](ctx context.Context, ch <-chan T) <-chan []T {
 
 		for {
 			select {
-			case item := <-ch:
+			case item, ok := <-ch:
+				if !ok {
+					return
+				}
+
 				select {
 				case out <- []T{item}:
 				case <-ctx.Done():


### PR DESCRIPTION
instead of outputting zero values.