### PR TITLE
Show diff of dependencies in GitHub Actions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -78,3 +78,31 @@ jobs:
             gitdiff="$(git diff -U0)"
             echo "$gitdiff"
             test -z "$gitdiff"
+
+  vendor-diff:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/setup-go@v3
+      with:
+        go-version: ^1.18
+
+    - name: Checkout base commit
+      uses: actions/checkout@v3
+      with:
+        path: a
+        ref: ${{ github.base_ref }}
+    - name: Download dependencies of base commit
+      run: go mod vendor
+      working-directory: a
+
+    - name: Checkout PR
+      uses: actions/checkout@v3
+      with:
+        path: b
+    - name: Download dependencies of PR
+      run: go mod vendor
+      working-directory: b
+
+    - name: Diff of dependencies
+      run: diff -ur --color=always a/vendor b/vendor || true


### PR DESCRIPTION
dependabot adds a link showing the diff of the dependency but when there are changes in indirect dependencies, these have to be diffed manually. This commit vendors the dependencies before and after a PR and outputs the diff.

This automates something I've been doing manually for dependabot PRs so far.

### Review/merge procedure

The PR currently includes a dependabot commit for testing/demonstrating the functionality. My suggestion for how to proceed:
1. Review/update PR until looking good.
2. Once reviewer(s) is (are) happy, I'll remove the dependabot commit leaving the other commit as is.
3. Final approval.
4. Merge.