### PR TITLE
Save memory during config sync via SyncSubject#FactoryForDelta()

### DIFF
--- a/pkg/common/sync_subject.go
+++ b/pkg/common/sync_subject.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"github.com/icinga/icingadb/pkg/contracts"
+	v1 "github.com/icinga/icingadb/pkg/icingadb/v1"
 	"github.com/icinga/icingadb/pkg/utils"
 )
 
@@ -44,6 +45,18 @@ func (s SyncSubject) Entity() contracts.Entity {
 
 // Factory returns the entity factory function that calls Init() on the created contracts.Entity if applicable.
 func (s SyncSubject) Factory() contracts.EntityFactoryFunc {
+	return s.factory
+}
+
+// FactoryForDelta behaves like Factory() unless s is WithChecksum().
+// In the latter case it returns a factory for EntityWithChecksum instead.
+// Rationale: Sync#ApplyDelta() uses its input entities which are WithChecksum() only for the delta itself
+// and not for insertion into the database, so EntityWithChecksum is enough. And it consumes less memory.
+func (s SyncSubject) FactoryForDelta() contracts.EntityFactoryFunc {
+	if s.withChecksum {
+		return v1.NewEntityWithChecksum
+	}
+
 	return s.factory
 }
 

--- a/pkg/icingadb/sync.go
+++ b/pkg/icingadb/sync.go
@@ -84,7 +84,9 @@ func (s Sync) Sync(ctx context.Context, subject *common.SyncSubject) error {
 	}
 
 	actual, dbErrs := s.db.YieldAll(
-		ctx, subject.Factory(), s.db.BuildSelectStmt(NewScopedEntity(subject.Entity(), e.Meta()), subject.Entity().Fingerprint()), e.Meta())
+		ctx, subject.FactoryForDelta(),
+		s.db.BuildSelectStmt(NewScopedEntity(subject.Entity(), e.Meta()), subject.Entity().Fingerprint()), e.Meta(),
+	)
 	// Let errors from DB cancel our group.
 	com.ErrgroupReceive(g, dbErrs)
 
@@ -184,7 +186,9 @@ func (s Sync) SyncCustomvars(ctx context.Context) error {
 	com.ErrgroupReceive(g, errs)
 
 	actualCvs, errs := s.db.YieldAll(
-		ctx, cv.Factory(), s.db.BuildSelectStmt(NewScopedEntity(cv.Entity(), e.Meta()), cv.Entity().Fingerprint()), e.Meta())
+		ctx, cv.FactoryForDelta(),
+		s.db.BuildSelectStmt(NewScopedEntity(cv.Entity(), e.Meta()), cv.Entity().Fingerprint()), e.Meta(),
+	)
 	com.ErrgroupReceive(g, errs)
 
 	g.Go(func() error {
@@ -194,7 +198,9 @@ func (s Sync) SyncCustomvars(ctx context.Context) error {
 	flatCv := common.NewSyncSubject(v1.NewCustomvarFlat)
 
 	actualFlatCvs, errs := s.db.YieldAll(
-		ctx, flatCv.Factory(), s.db.BuildSelectStmt(NewScopedEntity(flatCv.Entity(), e.Meta()), flatCv.Entity().Fingerprint()), e.Meta())
+		ctx, flatCv.FactoryForDelta(),
+		s.db.BuildSelectStmt(NewScopedEntity(flatCv.Entity(), e.Meta()), flatCv.Entity().Fingerprint()), e.Meta(),
+	)
 	com.ErrgroupReceive(g, errs)
 
 	g.Go(func() error {

--- a/pkg/icingadb/v1/entity.go
+++ b/pkg/icingadb/v1/entity.go
@@ -22,3 +22,7 @@ type EntityWithChecksum struct {
 func (e EntityWithChecksum) Fingerprint() contracts.Fingerprinter {
 	return e
 }
+
+func NewEntityWithChecksum() contracts.Entity {
+	return &EntityWithChecksum{}
+}

--- a/pkg/icingaredis/client.go
+++ b/pkg/icingaredis/client.go
@@ -222,7 +222,7 @@ func (c Client) YieldAll(ctx context.Context, subject *common.SyncSubject) (<-ch
 	// Let errors from HYield cancel the group.
 	com.ErrgroupReceive(g, errs)
 
-	desired, errs := CreateEntities(ctx, subject.Factory(), pairs, runtime.NumCPU())
+	desired, errs := CreateEntities(ctx, subject.FactoryForDelta(), pairs, runtime.NumCPU())
 	// Let errors from CreateEntities cancel the group.
 	com.ErrgroupReceive(g, errs)
 


### PR DESCRIPTION
Code comment TL;DR: Allocate the same amount of smaller data structures

## Peek of reserved memory

* Before: 3.5G
* After: 2.8G