### PR TITLE
Improve how docs describe adding repo to SLES

### DIFF
--- a/doc/02-Installation.md
+++ b/doc/02-Installation.md
@@ -115,7 +115,12 @@ wget https://packages.icinga.com/subscription/rhel/ICINGA-release.repo -O /etc/y
 ```bash
 rpm --import https://packages.icinga.com/icinga.key
 
-zypper ar https://packages.icinga.com/subscription/sles/ICINGA-release.repo
+wget https://packages.icinga.com/subscription/sles/ICINGA-release.repo -O /etc/zypp/repos.d/ICINGA-release.repo
+```
+
+Now edit your `/etc/zypp/repos.d/ICINGA-release.repo` file with your credentials.
+
+```
 zypper ref
 ```
 <!-- {% endif %} -->


### PR DESCRIPTION
This contains a more efficient way of adding the Icinga repos to a SLES system. For more information, check out ticket number 42655. 