### PR TITLE
Improve documentation for migration tool

### DIFF
--- a/doc/icingadb-migration.example.yml
+++ b/doc/icingadb-migration.example.yml
@@ -1,0 +1,25 @@
+icinga2:
+  # Content of /var/lib/icinga2/icingadb.env
+  env: "da39a3e..."
+
+# IDO database
+ido:
+  type: mysql # or "pgsql" for PostgreSQL
+  host: 192.0.2.1
+  #port: 3306
+  database: icinga
+  user: icinga
+  password: CHANGEME
+
+  # Input time range
+  #from: 0
+  #to: 2147483647
+
+# Icinga DB database
+icingadb:
+  type: mysql # or "pgsql" for PostgreSQL
+  host: 2001:db8::1
+  #port: 3306
+  database: icingadb
+  user: icingadb
+  password: CHANGEME


### PR DESCRIPTION
1. Moves the example config to a separate file one can just download.
2. Establishes some kind of standard workflow for the migration.

## TODO
* [x] ~Figure out if we want to keep the endpoint setting or just use NULL ([context](https://github.com/Icinga/icingadb/pull/253#issuecomment-1296932224)), then either write documentation for it or remove it altogether.~
* [x] Remove `endpoint` option in other PR (#541)