### PR TITLE
Log UNIX socket address w/o port number

### DIFF
--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -18,7 +18,6 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
-	"net"
 	"os"
 	"os/signal"
 	"sync"
@@ -64,7 +63,7 @@ func run() int {
 	}
 	defer db.Close()
 	{
-		logger.Infof("Connecting to database at '%s'", net.JoinHostPort(cmd.Config.Database.Host, fmt.Sprint(cmd.Config.Database.Port)))
+		logger.Infof("Connecting to database at '%s'", utils.JoinHostPort(cmd.Config.Database.Host, cmd.Config.Database.Port))
 		err := db.Ping()
 		if err != nil {
 			logger.Fatalf("%+v", errors.Wrap(err, "can't connect to database"))
@@ -80,7 +79,7 @@ func run() int {
 		logger.Fatalf("%+v", errors.Wrap(err, "can't create Redis client from config"))
 	}
 	{
-		logger.Infof("Connecting to Redis at '%s'", net.JoinHostPort(cmd.Config.Redis.Host, fmt.Sprint(cmd.Config.Redis.Port)))
+		logger.Infof("Connecting to Redis at '%s'", utils.JoinHostPort(cmd.Config.Redis.Host, cmd.Config.Redis.Port))
 		_, err := rc.Ping(context.Background()).Result()
 		if err != nil {
 			logger.Fatalf("%+v", errors.Wrap(err, "can't connect to Redis"))

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/exp/utf8string"
 	"math"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -205,4 +206,13 @@ func MaxInt(x, y int) int {
 	}
 
 	return y
+}
+
+// JoinHostPort is like its equivalent in net., but handles UNIX sockets as well.
+func JoinHostPort(host string, port int) string {
+	if strings.HasPrefix(host, "/") {
+		return host
+	}
+
+	return net.JoinHostPort(host, fmt.Sprint(port))
 }


### PR DESCRIPTION
E.g. not
Connecting to database at '/var/lib/mysql/mysql.sock:0' Connecting to Redis at '/run/icingadb-redis/icingadb-redis-server.sock:6380'