### PR TITLE
GitHub Actions: run Go lint job with at least 1.19

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.18.x
+          go-version: ^1.19
 
       - uses: dominikh/staticcheck-action@29e9b80fb8de0521ba4ed3fdf68fed5bbe82a2d2 # v1.1.0
         with:


### PR DESCRIPTION
The jobs were failing and the output contained: "note: module requires Go 1.19" (e.g. https://github.com/Icinga/icingadb/actions/runs/4233417770/jobs/7354361633)

FYI: `^1.19` means `>= 1.19 && <2.0` (https://www.npmjs.com/package/semver#caret-ranges-123-025-004)