### PR TITLE
retry.Retryable(): treat ENOENT (AF_UNIX) like ECONNREFUSED, i.e. also retry

### DIFF
--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -114,9 +114,9 @@ func Retryable(err error) bool {
 		// which is not considered temporary or timed out by Go.
 		err = opError.Err
 	}
-	if errors.Is(err, syscall.ECONNREFUSED) {
+	if errors.Is(err, syscall.ECONNREFUSED) || errors.Is(err, syscall.ENOENT) {
 		// syscall errors provide Temporary() and Timeout(),
-		// which do not include ECONNREFUSED, so we check this ourselves.
+		// which do not include ECONNREFUSED or ENOENT, so we check these ourselves.
 		return true
 	}
 	if errors.Is(err, syscall.ECONNRESET) {


### PR DESCRIPTION
During connect(2) we may get ECONNREFUSED between server's bind(2) and listen(2), but the most downtime between boot and service start the socket won't exist, yet. I.e. ENOENT is the de facto ECONNREFUSED of *nix sockets.

Tested this new commit vs. its parent commit. Test case - see:

fixes #543