### PR TITLE
Merge network and database error retryability detection functions

### DIFF
--- a/pkg/icingadb/ha.go
+++ b/pkg/icingadb/ha.go
@@ -319,7 +319,7 @@ func (h *HA) realize(ctx context.Context, s *icingaredisv1.IcingaStatus, t *type
 
 			return nil
 		},
-		IsRetryable,
+		retry.Retryable,
 		backoff.NewExponentialWithJitter(time.Millisecond*256, time.Second*3),
 		retry.Settings{
 			OnError: func(_ time.Duration, attempt uint64, err, lastErr error) {


### PR DESCRIPTION
so that connection attempts will also be re-tried on RDBMS-specific errors, e.g. Postgres' 57P03 (the database system is starting up), not to crash. On the other hand, SQL operations which are safe to retry on SQL errors are also safe to retry on network errors.

fixes #561

## Before

https://github.com/Icinga/icingadb/issues/561#issuecomment-1564120245

## After

```
2023-05-26T12:19:58.736+0200	INFO	icingadb	Starting Icinga DB
2023-05-26T12:19:58.736+0200	INFO	icingadb	Connecting to database at 'localhost:2345'
2023-05-26T12:20:01.610+0200	WARN	database	Can't connect to database. Retrying	{"error": "pq: the database system is starting up"}
2023-05-26T12:20:08.612+0200	INFO	database	Reconnected to database{"after": "9.87615987s", "attempts": 4}
2023-05-26T12:20:08.620+0200	FATAL	icingadb	pq: relation "icingadb_schema" does not exist
can't check database schema version
...
```