### PR TITLE
Write a hint for empty arrays/dicts into `customvar_flat`

### DIFF
--- a/pkg/flatten/flatten.go
+++ b/pkg/flatten/flatten.go
@@ -1,26 +1,43 @@
 package flatten
 
 import (
+	"database/sql"
+	"fmt"
+	"github.com/icinga/icingadb/pkg/types"
 	"strconv"
 )
 
 // Flatten creates flat, one-dimensional maps from arbitrarily nested values, e.g. JSON.
-func Flatten(value interface{}, prefix string) map[string]interface{} {
+func Flatten(value interface{}, prefix string) map[string]types.String {
 	var flatten func(string, interface{})
-	flattened := make(map[string]interface{})
+	flattened := make(map[string]types.String)
 
 	flatten = func(key string, value interface{}) {
 		switch value := value.(type) {
 		case map[string]interface{}:
+			if len(value) == 0 {
+				flattened[key] = types.String{}
+				break
+			}
+
 			for k, v := range value {
 				flatten(key+"."+k, v)
 			}
 		case []interface{}:
+			if len(value) == 0 {
+				flattened[key] = types.String{}
+				break
+			}
+
 			for i, v := range value {
 				flatten(key+"["+strconv.Itoa(i)+"]", v)
 			}
 		default:
-			flattened[key] = value
+			val := "null"
+			if value != nil {
+				val = fmt.Sprintf("%v", value)
+			}
+			flattened[key] = types.String{NullString: sql.NullString{String: val, Valid: true}}
 		}
 	}
 

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -983,7 +983,7 @@ CREATE TABLE customvar_flat (
   flatname_checksum binary(20) NOT NULL COMMENT 'sha1(flatname after conversion)',
 
   flatname varchar(512) COLLATE utf8mb4_unicode_ci NOT NULL COMMENT 'Path converted with `.` and `[ ]`',
-  flatvalue text NOT NULL,
+  flatvalue text DEFAULT NULL,
 
   PRIMARY KEY (id),
 

--- a/schema/mysql/upgrades/1.2.0.sql
+++ b/schema/mysql/upgrades/1.2.0.sql
@@ -1,0 +1,1 @@
+ALTER TABLE customvar_flat MODIFY COLUMN flatvalue text DEFAULT NULL;

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -1553,7 +1553,7 @@ CREATE TABLE customvar_flat (
   flatname_checksum bytea20 NOT NULL,
 
   flatname citext NOT NULL,
-  flatvalue text NOT NULL,
+  flatvalue text DEFAULT NULL,
 
   CONSTRAINT pk_customvar_flat PRIMARY KEY (id)
 );

--- a/schema/pgsql/upgrades/1.2.0.sql
+++ b/schema/pgsql/upgrades/1.2.0.sql
@@ -1,0 +1,1 @@
+ALTER TABLE customvar_flat ALTER COLUMN flatvalue DROP NOT NULL;


### PR DESCRIPTION
Just inserts empty custom vars of type `array` & `map` with `NULL` value in to the `customvar_flat` table.

fixes #597 