### PR TITLE
Config parsing: fail on unknown fields and print them

### DIFF
--- a/cmd/icingadb-migrate/main.go
+++ b/cmd/icingadb-migrate/main.go
@@ -125,7 +125,7 @@ func parseConfig(f *Flags) (_ *Config, exit int) {
 		return nil, 2
 	}
 
-	if err := yaml.NewDecoder(cf).Decode(c); err != nil {
+	if err := yaml.NewDecoder(cf, yaml.DisallowUnknownField()).Decode(c); err != nil {
 		_, _ = fmt.Fprintf(os.Stderr, "can't parse config file: %s\n", err.Error())
 		return nil, 2
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,7 +54,7 @@ func FromYAMLFile(name string) (*Config, error) {
 	defer f.Close()
 
 	c := &Config{}
-	d := yaml.NewDecoder(f)
+	d := yaml.NewDecoder(f, yaml.DisallowUnknownField())
 
 	if err := defaults.Set(c); err != nil {
 		return nil, errors.Wrap(err, "can't set config defaults")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,69 @@
+package config
+
+import (
+	"github.com/creasty/defaults"
+	"github.com/icinga/icingadb/pkg/logging"
+	"github.com/stretchr/testify/require"
+	"os"
+	"testing"
+)
+
+func TestFromYAMLFile(t *testing.T) {
+	const miniConf = `
+database:
+  host: 192.0.2.1
+  database: icingadb
+  user: icingadb
+  password: icingadb
+
+redis:
+  host: 2001:db8::1
+`
+
+	subtests := []struct {
+		name   string
+		input  string
+		output *Config
+	}{
+		{
+			name:  "mini",
+			input: miniConf,
+			output: func() *Config {
+				c := &Config{}
+				_ = defaults.Set(c)
+
+				c.Database.Host = "192.0.2.1"
+				c.Database.Database = "icingadb"
+				c.Database.User = "icingadb"
+				c.Database.Password = "icingadb"
+
+				c.Redis.Host = "2001:db8::1"
+				c.Logging.Output = logging.CONSOLE
+
+				return c
+			}(),
+		},
+		{
+			name:   "mini-with-unknown",
+			input:  miniConf + "\nunknown: 42",
+			output: nil,
+		},
+	}
+
+	for _, st := range subtests {
+		t.Run(st.name, func(t *testing.T) {
+			tempFile, err := os.CreateTemp("", "")
+			require.NoError(t, err)
+			defer func() { _ = os.Remove(tempFile.Name()) }()
+
+			require.NoError(t, os.WriteFile(tempFile.Name(), []byte(st.input), 0o600))
+
+			if actual, err := FromYAMLFile(tempFile.Name()); st.output == nil {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, st.output, actual)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Useful against config validation or runtime failures caused by wrong field spelling or YAML indentation.

```
➜  icingadb git:(yaml.DisallowUnknownField) ✗ go run ./cmd/icingadb-migrate -c i2i.yml -t `mktemp -d`
can't parse config file: [1:1] unknown field "Icinga2"
>  1 | Icinga2:
       ^
   2 |   env: da39a3ee5e6b4b0d3255bfef95601890afd80709
   3 | ido:
   4 |   type: mysql
   5 |
exit status 2
```

refs #574

## TODO

* [x] review (non-author)
* [x] unit test that particular case in FromYAMLFile() (author)