### PR TITLE
schema: Add missing indices to `hostgroup` and `servicegroup`

### DIFF
--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -240,7 +240,9 @@ CREATE TABLE hostgroup (
 
   PRIMARY KEY (id),
 
-  INDEX idx_hostgroup_name (name) COMMENT 'Host/service/host group list filtered by host group name'
+  INDEX idx_hostgroup_display_name (display_name) COMMENT 'Hostgroup list filtered/ordered by display_name',
+  INDEX idx_hostgroup_name_ci (name_ci) COMMENT 'Hostgroup list filtered using quick search',
+  INDEX idx_hostgroup_name (name) COMMENT 'Host/service/host group list filtered by host group name; Hostgroup detail filter'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE hostgroup_member (
@@ -404,7 +406,9 @@ CREATE TABLE servicegroup (
 
   PRIMARY KEY (id),
 
-  INDEX idx_servicegroup_name (name) COMMENT 'Host/service/service group list filtered by service group name'
+  INDEX idx_servicegroup_display_name (display_name) COMMENT 'Servicegroup list filtered/ordered by display_name',
+  INDEX idx_servicegroup_name_ci (name_ci) COMMENT 'Servicegroup list filtered using quick search',
+  INDEX idx_servicegroup_name (name) COMMENT 'Host/service/service group list filtered by service group name; Servicegroup detail filter'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE servicegroup_member (

--- a/schema/mysql/upgrades/1.2.0.sql
+++ b/schema/mysql/upgrades/1.2.0.sql
@@ -2,3 +2,15 @@ ALTER TABLE customvar_flat MODIFY COLUMN flatvalue text DEFAULT NULL;
 
 ALTER TABLE customvar_flat
     ADD INDEX idx_customvar_flat_flatname_flatvalue (flatname, flatvalue(255)) COMMENT 'Lists filtered by custom variable';
+
+ALTER TABLE hostgroup
+    ADD INDEX idx_hostgroup_display_name (display_name) COMMENT 'Hostgroup list filtered/ordered by display_name',
+    ADD INDEX idx_hostgroup_name_ci (name_ci) COMMENT 'Hostgroup list filtered using quick search',
+    DROP INDEX idx_hostgroup_name,
+    ADD INDEX idx_hostgroup_name (name) COMMENT 'Host/service/host group list filtered by host group name; Hostgroup detail filter';
+
+ALTER TABLE servicegroup
+    ADD INDEX idx_servicegroup_display_name (display_name) COMMENT 'Servicegroup list filtered/ordered by display_name',
+    ADD INDEX idx_servicegroup_name_ci (name_ci) COMMENT 'Servicegroup list filtered using quick search',
+    DROP INDEX idx_servicegroup_name,
+    ADD INDEX idx_servicegroup_name (name) COMMENT 'Host/service/service group list filtered by service group name; Servicegroup detail filter';

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -305,6 +305,8 @@ ALTER TABLE hostgroup ALTER COLUMN name_checksum SET STORAGE PLAIN;
 ALTER TABLE hostgroup ALTER COLUMN properties_checksum SET STORAGE PLAIN;
 ALTER TABLE hostgroup ALTER COLUMN zone_id SET STORAGE PLAIN;
 
+CREATE INDEX idx_hostgroup_display_name ON hostgroup(display_name);
+CREATE INDEX idx_hostgroup_name_ci ON hostgroup(name_ci);
 CREATE INDEX idx_hostgroup_name ON hostgroup(name);
 
 COMMENT ON COLUMN hostgroup.id IS 'sha1(environment.id + name)';
@@ -313,7 +315,9 @@ COMMENT ON COLUMN hostgroup.name_checksum IS 'sha1(name)';
 COMMENT ON COLUMN hostgroup.properties_checksum IS 'sha1(all properties)';
 COMMENT ON COLUMN hostgroup.zone_id IS 'zone.id';
 
-COMMENT ON INDEX idx_hostgroup_name IS 'Host/service/host group list filtered by host group name';
+COMMENT ON INDEX idx_hostgroup_display_name IS 'Hostgroup list filtered/ordered by display_name';
+COMMENT ON INDEX idx_hostgroup_name_ci IS 'Hostgroup list filtered using quick search';
+COMMENT ON INDEX idx_hostgroup_name IS 'Host/service/host group list filtered by host group name; Hostgroup detail filter';
 
 CREATE TABLE hostgroup_member (
   id bytea20 NOT NULL,
@@ -577,8 +581,12 @@ COMMENT ON COLUMN servicegroup.name_checksum IS 'sha1(name)';
 COMMENT ON COLUMN servicegroup.properties_checksum IS 'sha1(all properties)';
 COMMENT ON COLUMN servicegroup.zone_id IS 'zone.id';
 
+CREATE INDEX idx_servicegroup_display_name ON servicegroup(display_name);
+CREATE INDEX idx_servicegroup_name_ci ON servicegroup(name_ci);
 CREATE INDEX idx_servicegroup_name ON servicegroup(name);
-COMMENT ON INDEX idx_servicegroup_name IS 'Host/service/service group list filtered by service group name';
+COMMENT ON INDEX idx_servicegroup_display_name IS 'Servicegroup list filtered/ordered by display_name';
+COMMENT ON INDEX idx_servicegroup_name_ci IS 'Servicegroup list filtered using quick search';
+COMMENT ON INDEX idx_servicegroup_name IS 'Host/service/service group list filtered by service group name; Servicegroup detail filter';
 
 CREATE TABLE servicegroup_member (
   id bytea20 NOT NULL,

--- a/schema/pgsql/upgrades/1.2.0.sql
+++ b/schema/pgsql/upgrades/1.2.0.sql
@@ -2,3 +2,15 @@ ALTER TABLE customvar_flat ALTER COLUMN flatvalue DROP NOT NULL;
 
 CREATE INDEX idx_customvar_flat_flatname_flatvalue ON customvar_flat(flatname, flatvalue);
 COMMENT ON INDEX idx_customvar_flat_flatname_flatvalue IS 'Lists filtered by custom variable';
+
+CREATE INDEX idx_hostgroup_display_name ON hostgroup(display_name);
+CREATE INDEX idx_hostgroup_name_ci ON hostgroup(name_ci);
+COMMENT ON INDEX idx_hostgroup_display_name IS 'Hostgroup list filtered/ordered by display_name';
+COMMENT ON INDEX idx_hostgroup_name_ci IS 'Hostgroup list filtered using quick search';
+COMMENT ON INDEX idx_hostgroup_name IS 'Host/service/host group list filtered by host group name; Hostgroup detail filter';
+
+CREATE INDEX idx_servicegroup_display_name ON servicegroup(display_name);
+CREATE INDEX idx_servicegroup_name_ci ON servicegroup(name_ci);
+COMMENT ON INDEX idx_servicegroup_display_name IS 'Servicegroup list filtered/ordered by display_name';
+COMMENT ON INDEX idx_servicegroup_name_ci IS 'Servicegroup list filtered using quick search';
+COMMENT ON INDEX idx_servicegroup_name IS 'Host/service/service group list filtered by service group name; Servicegroup detail filter';


### PR DESCRIPTION
These new indices make these tables consistent with `usergroup`.

fixes #615