### PR TITLE
cmd/icingadb-migrate: if Downtime cancel time is missing, fall back to scheduled end

### DIFF
--- a/cmd/icingadb-migrate/convert.go
+++ b/cmd/icingadb-migrate/convert.go
@@ -274,7 +274,7 @@ func convertDowntimeRows(
 		}
 
 		if row.WasCancelled != 0 {
-			cancelTime = actualEnd
+			cancelTime = endTime
 		}
 
 		downtimeHistory = append(downtimeHistory, &history.DowntimeHistory{


### PR DESCRIPTION
sla_history_downtime#downtime_end is required. In case of Downtime cancellation it's the cancel time. If it's (unexpectedly) missing, assume the scheduled end.

~fixes~ #621

## Reproduction

* Cancel a Downtime using IDO
* `update icinga_downtimehistory set actual_end_time=null, actual_end_time_usec=0;`
* Migrate the history

## Before

```
2023-07-27T12:14:30.458+0200	FATAL	icingadb-migrate/main.go:449	Error 1048 (23000): Column 'downtime_end' cannot be null
can't perform "INSERT INTO \"sla_history_downtime\" (\"endpoint_id\", \"object_type\", \"host_id\", \"service_id\", \"downtime_end\", \"downtime_start\", \"downtime_id\", \"environment_id\") VALUES (:endpoint_id, :object_type, :host_id, :service_id, :downtime_end, :downtime_start, :downtime_id, :environment_id) ON DUPLICATE KEY UPDATE \"endpoint_id\" = \"endpoint_id\""
```

## After

```
2023-07-27T12:15:17.868+0200	INFO	icingadb-migrate/main.go:106	Actually migrating
ack & comment   0 %    0s  0/s
downtime 100 %    0s  0/s
flapping   0 %    0s  0/s
notification   0 %    0s  0/s
state   0 %    0s  0/s
2023-07-27T12:15:17.887+0200	INFO	icingadb-migrate/main.go:109	Cleaning up cache
```