### PR TITLE
cmd/icingadb-migrate: ignore icinga_downtimehistory#was_started=0 rows

### DIFF
--- a/cmd/icingadb-migrate/convert.go
+++ b/cmd/icingadb-migrate/convert.go
@@ -224,6 +224,7 @@ type downtimeRow = struct {
 	Duration            int64
 	ScheduledStartTime  sql.NullInt64
 	ScheduledEndTime    int64
+	WasStarted          uint8
 	ActualStartTime     int64
 	ActualStartTimeUsec uint32
 	ActualEndTime       int64
@@ -246,7 +247,7 @@ func convertDowntimeRows(
 	for _, row := range idoRows {
 		checkpoint = row.DowntimehistoryId
 
-		if !row.ScheduledStartTime.Valid {
+		if !row.ScheduledStartTime.Valid || row.WasStarted == 0 {
 			continue
 		}
 

--- a/cmd/icingadb-migrate/embed/downtime_query.sql
+++ b/cmd/icingadb-migrate/embed/downtime_query.sql
@@ -1,6 +1,6 @@
 SELECT dh.downtimehistory_id, UNIX_TIMESTAMP(dh.entry_time) entry_time, dh.author_name, dh.comment_data,
   dh.is_fixed, dh.duration, UNIX_TIMESTAMP(dh.scheduled_start_time) scheduled_start_time,
-  COALESCE(UNIX_TIMESTAMP(dh.scheduled_end_time), 0) scheduled_end_time,
+  COALESCE(UNIX_TIMESTAMP(dh.scheduled_end_time), 0) scheduled_end_time, dh.was_started,
   COALESCE(UNIX_TIMESTAMP(dh.actual_start_time), 0) actual_start_time, dh.actual_start_time_usec,
   COALESCE(UNIX_TIMESTAMP(dh.actual_end_time), 0) actual_end_time, dh.actual_end_time_usec, dh.was_cancelled,
   COALESCE(UNIX_TIMESTAMP(dh.trigger_time), 0) trigger_time, dh.name, o.objecttype_id,


### PR DESCRIPTION
Such appear e.g. for scheduled but never triggered flexible Downtimes. Not triggered = no events.

In addition this

fixes #621

for reasons Julian described in https://github.com/Icinga/icingadb/pull/622#pullrequestreview-1550032165. (I tested that.)