### PR TITLE
Schema: change sort order of history event type enum

### DIFF
--- a/schema/mysql/upgrades/1.2.0.sql
+++ b/schema/mysql/upgrades/1.2.0.sql
@@ -14,3 +14,17 @@ ALTER TABLE servicegroup
     ADD INDEX idx_servicegroup_name_ci (name_ci) COMMENT 'Servicegroup list filtered using quick search',
     DROP INDEX idx_servicegroup_name,
     ADD INDEX idx_servicegroup_name (name) COMMENT 'Host/service/service group list filtered by service group name; Servicegroup detail filter';
+
+-- The following sequence of statements changes the type of history.event_type like the following statement would:
+--
+--   ALTER TABLE history MODIFY event_type enum('state_change', 'ack_clear', 'downtime_end', 'flapping_end', 'comment_remove', 'comment_add', 'flapping_start', 'downtime_start', 'ack_set', 'notification') NOT NULL;
+--
+-- It's just much faster to add a second column, copy the column using an UPDATE statement and then replace the
+-- old column with the one just generated. Table locking ensures that no other connection inserts data in the meantime.
+LOCK TABLES history WRITE;
+ALTER TABLE history ADD COLUMN event_type_new enum('state_change', 'ack_clear', 'downtime_end', 'flapping_end', 'comment_remove', 'comment_add', 'flapping_start', 'downtime_start', 'ack_set', 'notification') NOT NULL AFTER event_type;
+UPDATE history SET event_type_new = event_type;
+ALTER TABLE history
+    DROP COLUMN event_type,
+    CHANGE COLUMN event_type_new event_type enum('state_change', 'ack_clear', 'downtime_end', 'flapping_end', 'comment_remove', 'comment_add', 'flapping_start', 'downtime_start', 'ack_set', 'notification') NOT NULL;
+UNLOCK TABLES;

--- a/schema/pgsql/upgrades/1.2.0.sql
+++ b/schema/pgsql/upgrades/1.2.0.sql
@@ -14,3 +14,11 @@ CREATE INDEX idx_servicegroup_name_ci ON servicegroup(name_ci);
 COMMENT ON INDEX idx_servicegroup_display_name IS 'Servicegroup list filtered/ordered by display_name';
 COMMENT ON INDEX idx_servicegroup_name_ci IS 'Servicegroup list filtered using quick search';
 COMMENT ON INDEX idx_servicegroup_name IS 'Host/service/service group list filtered by service group name; Servicegroup detail filter';
+
+ALTER TYPE history_type RENAME TO history_type_old;
+CREATE TYPE history_type AS ENUM ( 'state_change', 'ack_clear', 'downtime_end', 'flapping_end', 'comment_remove', 'comment_add', 'flapping_start', 'downtime_start', 'ack_set', 'notification' );
+ALTER TABLE history
+  ALTER COLUMN event_type DROP DEFAULT,
+  ALTER COLUMN event_type TYPE history_type USING event_type::text::history_type,
+  ALTER COLUMN event_type SET DEFAULT 'state_change'::history_type;
+DROP TYPE history_type_old;


### PR DESCRIPTION
This improves the resulting sort order when `ORDER BY event_time, event_type` is used. `state_change` comes first as it can cause many of the other events like trigger downtimes, remove acknowledgements and send notifications. Similarly, `notification` comes last as any other event can result in a notification. This will result in history events for scenarios like state changes, triggers downtime, sends downtime start notification being sorted in that order.

Apart from that, end events sort before the corresponding start events as any ack/comment/downtime/flapping period should last for more than a millisecond, therefore if there should be two events within the same millisecond, the end event corresponds to the older period and is sorted first. The remaining order is by impact and cause, see inline comment or https://github.com/Icinga/icingadb/pull/626#discussion_r1284399172.

Both schema upgrades will lock the `history` table for a few minutes, blocking other read and write access including by the Icinga DB daemon and Icinga DB Web. On my (totally representative) laptop, this was about 2 minutes for 19M rows in MariaDB and 8 minutes for 22M rows in PostgreSQL (worst-case times, I've also seen it faster on both).

If you're wondering about why the default value for PostgreSQL is changed: I don't think that this does anything useful, it's just the first enum value to emulate that default behavior from MySQL.

### For the review
* It's better if more people look at this, we really don't want to have to change this again.
* Please double check the ordering, ideally make your own thoughts and check if they are compatible with my suggestion.

fixes #614
refs https://github.com/Icinga/icingadb-web/issues/587