### PR TITLE
GitHub Actions: use actions/setup-go@v4 and go-version: 1.x

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -11,9 +11,9 @@ jobs:
     steps:
       - run: sudo apt install -y moreutils
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: 1.x
 
       - uses: actions/checkout@v2
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,9 +16,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: 1.x
 
       - run: go build -gcflags="-m" ./...
 
@@ -29,9 +29,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
-          go-version: ^1.19
+          go-version: 1.x
 
       - uses: dominikh/staticcheck-action@29e9b80fb8de0521ba4ed3fdf68fed5bbe82a2d2 # v1.1.0
         with:
@@ -42,9 +42,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: 1.x
 
       - run: go vet ./...
 
@@ -53,9 +53,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: 1.x
 
       - name: Run gofmt -d .
         run: |
@@ -68,9 +68,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: 1.x
 
       - name: Run go mod tidy
         run: |
@@ -83,9 +83,9 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v3
+    - uses: actions/setup-go@v4
       with:
-        go-version: ^1.18
+        go-version: 1.x
 
     - name: Checkout base commit
       uses: actions/checkout@v3

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -26,9 +26,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: '^1.18'
+          go-version: 1.x
       - name: Build Icinga DB
         run: go build ./cmd/icingadb
         env:

--- a/.github/workflows/sql.yml
+++ b/.github/workflows/sql.yml
@@ -36,9 +36,9 @@ jobs:
 
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v1
+        uses: actions/setup-go@v4
         with:
-          go-version: '^1.16'
+          go-version: 1.x
 
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -12,9 +12,9 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v4
         with:
-          go-version: 1.18.x
+          go-version: 1.x
       - name: Check version
         # TODO(elippmann): Needs adjustments as soon as we release from (support) branches too.
         run: |

--- a/pkg/icingadb/v1/environment.go
+++ b/pkg/icingadb/v1/environment.go
@@ -22,10 +22,10 @@ func (e *Environment) Meta() *EnvironmentMeta {
 
 // EnvironmentFromContext returns the Environment value stored in ctx, if any:
 //
-// 	e, ok := EnvironmentFromContext(ctx)
-// 	if !ok {
-// 		// Error handling.
-// 	}
+//	e, ok := EnvironmentFromContext(ctx)
+//	if !ok {
+//		// Error handling.
+//	}
 func EnvironmentFromContext(ctx context.Context) (*Environment, bool) {
 	if e, ok := ctx.Value(environmentContextKey).(*Environment); ok {
 		return e, true

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -55,12 +55,12 @@ func Key(name string, sep byte) string {
 //
 // Timed should be installed by defer:
 //
-//  func TimedExample(logger *zap.SugaredLogger) {
-//  	defer utils.Timed(time.Now(), func(elapsed time.Duration) {
-//  		logger.Debugf("Executed job in %s", elapsed)
-//  	})
-//  	job()
-//  }
+//	func TimedExample(logger *zap.SugaredLogger) {
+//		defer utils.Timed(time.Now(), func(elapsed time.Duration) {
+//			logger.Debugf("Executed job in %s", elapsed)
+//		})
+//		job()
+//	}
 func Timed(start time.Time, callback func(elapsed time.Duration)) {
 	callback(time.Since(start))
 }
@@ -158,20 +158,20 @@ func Ellipsize(s string, limit int) string {
 //
 // Example usage:
 //
-//  # snake_case
-//  ConvertCamelCase(s, unicode.Lower, '_')
+//	# snake_case
+//	ConvertCamelCase(s, unicode.Lower, '_')
 //
-//  # SCREAMING_SNAKE_CASE
-//  ConvertCamelCase(s, unicode.Upper, '_')
+//	# SCREAMING_SNAKE_CASE
+//	ConvertCamelCase(s, unicode.Upper, '_')
 //
-//  # kebab-case
-//  ConvertCamelCase(s, unicode.Lower, '-')
+//	# kebab-case
+//	ConvertCamelCase(s, unicode.Lower, '-')
 //
-//  # SCREAMING-KEBAB-CASE
-//  ConvertCamelCase(s, unicode.Upper, '-')
+//	# SCREAMING-KEBAB-CASE
+//	ConvertCamelCase(s, unicode.Upper, '-')
 //
-//  # other.separator
-//  ConvertCamelCase(s, unicode.Lower, '.')
+//	# other.separator
+//	ConvertCamelCase(s, unicode.Lower, '.')
 func ConvertCamelCase(s string, _case int, sep byte) string {
 	r := []rune(s)
 	b := strings.Builder{}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -17,14 +17,14 @@ type VersionInfo struct {
 }
 
 // Version determines version and commit information based on multiple data sources:
-//  - Version information dynamically added by `git archive` in the remaining to parameters.
-//  - A hardcoded version number passed as first parameter.
-//  - Commit information added to the binary by `go build`.
+//   - Version information dynamically added by `git archive` in the remaining to parameters.
+//   - A hardcoded version number passed as first parameter.
+//   - Commit information added to the binary by `go build`.
 //
 // It's supposed to be called like this in combination with setting the `export-subst` attribute for the corresponding
 // file in .gitattributes:
 //
-//     var Version = version.Version("1.0.0-rc2", "$Format:%(describe)$", "$Format:%H$")
+//	var Version = version.Version("1.0.0-rc2", "$Format:%(describe)$", "$Format:%H$")
 //
 // When exported using `git archive`, the placeholders are replaced in the file and this version information is
 // preferred. Otherwise the hardcoded version is used and augmented with commit information from the build metadata.


### PR DESCRIPTION
There was a mix of diferent action and Go versions specified throughout the GitHub Actions workflow configs. In general, we want to be compatible with the latest Go 1.x version, so just specify that instead of bumping versions everywhere when necessary.

At the same time, bump the actions/setup-go to v4, the latest currently available version. This prefers versions already cached on the runner and enables automatic caching for dependencies.

Also requires some reformatting of comments, looks like `go fmt` likes indentation within comments to look differently now.

The main motivation for this change is to allow upgrading go.uber.org/zap from 1.24.0 to 1.25.0 which no longer works with Go 1.18 (see #632).