### PR TITLE
GitHub Actions: change master to main

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -2,7 +2,7 @@ name: Compliance
 on:
   push:
     branches:
-      - master
+      - main
   pull_request: {}
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -4,7 +4,7 @@ on:
   pull_request: {}
   push:
     branches:
-      - master
+      - main
   release:
     types:
       - published

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@ name: Go
 on:
   push:
     branches:
-      - master
+      - main
   pull_request: {}
 
 jobs:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -3,7 +3,7 @@ name: Integration Tests
 on:
   push:
     branches:
-      - master
+      - main
   pull_request: {}
   schedule:
     - cron: '57 3 * * *'

--- a/.github/workflows/sql.yml
+++ b/.github/workflows/sql.yml
@@ -3,7 +3,7 @@ name: SQL
 on:
   push:
     branches:
-      - master
+      - main
   pull_request: {}
 
 jobs:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -2,7 +2,7 @@ name: Version
 on:
   push:
     branches:
-      - master
+      - main
   pull_request: {}
 
 jobs:


### PR DESCRIPTION
The branch was renamed, the same change has to be done in the GitHub Actions config so that the workflow continue to run.