### PR TITLE
GitHub Actions: also run on support branches

### DIFF
--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'support/*'
   pull_request: {}
 
 jobs:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,6 +5,7 @@ on:
   push:
     branches:
       - main
+      - 'support/*'
   release:
     types:
       - published

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'support/*'
   pull_request: {}
 
 jobs:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'support/*'
   pull_request: {}
   schedule:
     - cron: '57 3 * * *'

--- a/.github/workflows/sql.yml
+++ b/.github/workflows/sql.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - 'support/*'
   pull_request: {}
 
 jobs:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      - 'support/*'
   pull_request: {}
 
 jobs:


### PR DESCRIPTION
Merge into `support/1.1` to get GitHub Actions in the already created support branch.