### PR TITLE
doc/04-Upgrading.md: Fix path for schema upgrades

### DIFF
--- a/doc/04-Upgrading.md
+++ b/doc/04-Upgrading.md
@@ -6,8 +6,8 @@ If you are upgrading across multiple versions, make sure to follow the steps for
 ## Upgrading to Icinga DB v1.1.1
 
 Please apply the `1.1.1.sql` upgrade script to your database.
-For package installations, you can find this file at `/usr/share/doc/icingadb/schema/mysql/upgrades/` or
-`/usr/share/doc/icingadb/schema/pgsql/upgrades/`, depending on your database type.
+For package installations, you can find this file at `/usr/share/icingadb/schema/mysql/upgrades/` or
+`/usr/share/icingadb/schema/pgsql/upgrades/`, depending on your database type.
 
 Note that this upgrade will change the `history` table, which can take some time depending on the size of the table and
 the performance of the database. While the upgrade is running, that table will be locked and can't be accessed. This
@@ -28,7 +28,7 @@ restart the daemon when upgrading the package.
 **Database Schema**
 
 * For MySQL databases, please apply the `1.0.0.sql` upgrade script.
-  For package installations, you can find this file at `/usr/share/doc/icingadb/schema/mysql/upgrades/`.
+  For package installations, you can find this file at `/usr/share/icingadb/schema/mysql/upgrades/`.
 
 ## Upgrading to Icinga DB RC2
 


### PR DESCRIPTION
Looks like these were never in /usr/share/doc and the documentation was just wrong for 1.0.0.

The updated paths match both 1.0.0 release packages and the current snapshot packages:

```console
$ curl -s https://packages.icinga.com/debian/pool/main/i/icingadb/icingadb_1.0.0-1.bullseye_amd64.deb | dpkg --contents - |& grep -F .sql        
-rw-r--r-- root/root     59172 2022-06-29 19:33 ./usr/share/icingadb/schema/mysql/schema.sql
-rw-r--r-- root/root     28474 2022-06-29 19:33 ./usr/share/icingadb/schema/mysql/upgrades/1.0.0-rc2.sql
-rw-r--r-- root/root     12098 2022-06-29 19:33 ./usr/share/icingadb/schema/mysql/upgrades/1.0.0.sql
-rw-r--r-- root/root     93974 2022-06-29 19:33 ./usr/share/icingadb/schema/pgsql/schema.sql
```

```console
$ curl -s https://packages.icinga.com/fedora/36/release/x86_64/icingadb/icingadb-1.0.0-1.fc36.icinga.x86_64.rpm | rpm -qlp - |& grep -F .sql         
/usr/share/icingadb/schema/mysql/schema.sql
/usr/share/icingadb/schema/mysql/upgrades/1.0.0-rc2.sql
/usr/share/icingadb/schema/mysql/upgrades/1.0.0.sql
/usr/share/icingadb/schema/pgsql/schema.sql
```

```console
$ curl -s https://packages.icinga.com/debian/pool/main/i/icingadb/icingadb_1.1.0+86.g3f768dd-1691483080+debian11_amd64.deb | dpkg --contents - |& grep -F .sql
-rw-r--r-- root/root     60710 2023-08-08 10:08 ./usr/share/icingadb/schema/mysql/schema.sql
-rw-r--r-- root/root     28474 2023-08-08 10:08 ./usr/share/icingadb/schema/mysql/upgrades/1.0.0-rc2.sql
-rw-r--r-- root/root     12098 2023-08-08 10:08 ./usr/share/icingadb/schema/mysql/upgrades/1.0.0.sql
-rw-r--r-- root/root      2537 2023-08-08 10:08 ./usr/share/icingadb/schema/mysql/upgrades/1.1.1.sql
-rw-r--r-- root/root     95820 2023-08-08 10:08 ./usr/share/icingadb/schema/pgsql/schema.sql
-rw-r--r-- root/root      1915 2023-08-08 10:08 ./usr/share/icingadb/schema/pgsql/upgrades/1.1.1.sql
```

```console
$ curl -s https://packages.icinga.com/fedora/38/snapshot/x86_64/icingadb/icingadb-1.1.0+86.g3f768dd-1691483080.fc38.x86_64.rpm | rpm -qlp - |& grep -F .sql
/usr/share/icingadb/schema/mysql/schema.sql
/usr/share/icingadb/schema/mysql/upgrades/1.0.0-rc2.sql
/usr/share/icingadb/schema/mysql/upgrades/1.0.0.sql
/usr/share/icingadb/schema/mysql/upgrades/1.1.1.sql
/usr/share/icingadb/schema/pgsql/schema.sql
/usr/share/icingadb/schema/pgsql/upgrades/1.1.1.sql
```