### PR TITLE
retry.Retryable(): re-try MySQL error 1047 for a "not yet prepared node"

### DIFF
--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -150,6 +150,8 @@ func Retryable(err error) bool {
 			// 1213: Deadlock found when trying to get lock
 			// 2006: MySQL server has gone away
 			return true
+		case 1047: // Unknown command
+			return strings.Contains(e.Message, "not yet prepared node for application use")
 		default:
 			return false
 		}


### PR DESCRIPTION
During start a Galera cluster complains with "WSREP has not yet prepared node for application use". But the error code, 1047, stands for "Unknown command". So re-try only a "not yet prepared node", but not an "Unknown command".

ref/IP/48748

@NavidSassan Do you want packages with status quo plus this one?