### PR TITLE
History Sync: Use single, distinct DB connection

### DIFF
--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -132,7 +132,10 @@ func run() int {
 		cancelCtx()
 	}()
 	s := icingadb.NewSync(db, rc, logs.GetChildLogger("config-sync"))
-	hs := history.NewSync(db, rc, logs.GetChildLogger("history-sync"))
+	hs, err := history.NewSync(db, rc, logs.GetChildLogger("history-sync"))
+	if err != nil {
+		logger.Fatalf("%+v", errors.Wrap(err, "can't create history sync"))
+	}
 	rt := icingadb.NewRuntimeUpdates(db, rc, logs.GetChildLogger("runtime-updates"))
 	ods := overdue.NewSync(db, rc, logs.GetChildLogger("overdue-sync"))
 	ret := history.NewRetention(


### PR DESCRIPTION
This PR is another attempt at fixing #577 by using a single, distinct DB connection for the history sync.

The only database tables with foreign key constraints are found in the history context. By default - and for good reasons - a DB internally consists of a cluster of several database connections. However, if a multi-master database server setup is used, it can - and will - happen that this DB contains sessions to different servers and related queries will be submitted in the wrong order, at least in the eye of some database servers.

To prevent this problem, an extra DB with only one connection is used for the history sync. First, this required some refactoring on icingadb.DB, allowing to clone, copy or re-create a DB.

I have tested this change on top of #679, as it happened sometimes that my local Galera cluster wasn't completely ready yet. Thus, this PR should also be considered for merging.

This PR competes with #665 at fixing #577, as both are trying to solve the same issue. Even though I am not completely satisfied with the solution proposed here, I would like to emphasize that no database-specific commands are used and also no cluster sync is require for all `INSERTS`, also on unrelated tables, as [I wrote before](https://github.com/Icinga/icingadb/issues/577#issuecomment-1956773115).

Please feel free to test it and review it!