### PR TITLE
cmd/icingadb: Log Icinga DB version during startup

### DIFF
--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/go-redis/redis/v8"
+	"github.com/icinga/icingadb/internal"
 	"github.com/icinga/icingadb/internal/command"
 	"github.com/icinga/icingadb/pkg/common"
 	"github.com/icinga/icingadb/pkg/icingadb"
@@ -55,7 +56,7 @@ func run() int {
 	logger := logs.GetLogger()
 	defer logger.Sync()
 
-	logger.Info("Starting Icinga DB")
+	logger.Infof("Starting Icinga DB daemon (%s)", internal.Version.Version)
 
 	db, err := cmd.Database(logs.GetChildLogger("database"))
 	if err != nil {


### PR DESCRIPTION
To better recognize the Icinga DB version used in case of errors, it is now logged at startup.

If VCS is available during build, the current commit is included.
- Dirty VCS directory:
> 2024-03-11T14:36:29.317+0100    INFO    icingadb        Starting Icinga DB daemon (1.1.1-g0e9810c-dirty)
- Clean VCS directory:
> 2024-03-11T14:38:09.664+0100    INFO    icingadb        Starting Icinga DB daemon (1.1.1-geed8589)
- Build with `-buildvcs=false`:
> 2024-03-11T14:38:56.554+0100    INFO    icingadb        Starting Icinga DB daemon (1.1.1)

Closes #689.