### PR TITLE
Enhance HA "Taking over", "Handing over" logging

### DIFF
--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -162,8 +162,8 @@ func run() int {
 		hactx, cancelHactx := context.WithCancel(ctx)
 		for hactx.Err() == nil {
 			select {
-			case <-ha.Takeover():
-				logger.Info("Taking over")
+			case takeoverReason := <-ha.Takeover():
+				logger.Infow("Taking over", zap.String("reason", takeoverReason))
 
 				go func() {
 					for hactx.Err() == nil {
@@ -324,8 +324,8 @@ func run() int {
 						}
 					}
 				}()
-			case <-ha.Handover():
-				logger.Warn("Handing over")
+			case handoverReason := <-ha.Handover():
+				logger.Warnw("Handing over", zap.String("reason", handoverReason))
 
 				cancelHactx()
 			case <-hactx.Done():

--- a/pkg/icingaredis/heartbeat.go
+++ b/pkg/icingaredis/heartbeat.go
@@ -16,9 +16,9 @@ import (
 	"time"
 )
 
-// timeout defines how long a heartbeat may be absent if a heartbeat has already been received.
+// Timeout defines how long a heartbeat may be absent if a heartbeat has already been received.
 // After this time, a heartbeat loss is propagated.
-var timeout = 60 * time.Second
+const Timeout = time.Minute
 
 // Heartbeat periodically reads heartbeats from a Redis stream and signals in Beat channels when they are received.
 // Also signals on if the heartbeat is Lost.
@@ -141,9 +141,9 @@ func (h *Heartbeat) controller(ctx context.Context) {
 
 				atomic.StoreInt64(&h.lastReceivedMs, m.received.UnixMilli())
 				h.sendEvent(m)
-			case <-time.After(timeout):
+			case <-time.After(Timeout):
 				if h.active {
-					h.logger.Warnw("Lost Icinga heartbeat", zap.Duration("timeout", timeout))
+					h.logger.Warnw("Lost Icinga heartbeat", zap.Duration("timeout", Timeout))
 					h.sendEvent(nil)
 					h.active = false
 				} else {
@@ -217,5 +217,5 @@ func (m *HeartbeatMessage) EnvironmentID() (types.Binary, error) {
 
 // ExpiryTime returns the timestamp when the heartbeat expires.
 func (m *HeartbeatMessage) ExpiryTime() time.Time {
-	return m.received.Add(timeout)
+	return m.received.Add(Timeout)
 }


### PR DESCRIPTION
The reason for a switch in the HA roles was not always directly clear. This change now introduces additional logging, indicating the reasoning for either taking over or handing over the HA responsibility.

Next to additional logging messages, both the takeover and handover channel are now transporting a string to communicate the reason instead of an empty struct{}. By doing so, both the "Taking over" and "Handing over" log messages are enriched with a reason.

This also required a change in the suppressed logging handling of the HA.realize method, which got its logging enabled through the shouldLog parameter. Now, there are both recurring events, which might be suppressed, as well as state changing events, which should be logged. Therefore, and because the logTicker's functionality was not clear to me on first glance, I renamed it to routineLogTicker.

While dealing with the code, some function signature documentation were added, to ease both mine as well as the understanding of future readers.

Closes #688.