### PR TITLE
Update dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,3 @@ updates:
     interval: weekly
     time: '10:00'
   open-pull-requests-limit: 10
-  reviewers:
-  - Al2Klimov
-  - julianbrost
-  - lippserd

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,5 @@ updates:
 - package-ecosystem: gomod
   directory: "/"
   schedule:
-    interval: weekly
-    time: '10:00'
+    interval: daily
   open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,14 @@
 version: 2
 updates:
+
 - package-ecosystem: gomod
   directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+
+- package-ecosystem: gomod
+  directory: "/tests"
   schedule:
     interval: daily
   open-pull-requests-limit: 10


### PR DESCRIPTION
Multiple changes to the dependabot config:

1. Remove reviewers: For me personally, I receive notifications for the creation of the PRs anyways, so the extra review request provides no benefit to me. I also asked the others and they don't see a need either. Therefore, there's really no reason to maintain this list here.
2. Run daily: Running only weekly just adds latency until PRs are created with no apparent benefit. Multiple releases within a week for the same module happen rarely, so it doesn't reduce the number of PRs.
3. Enable go mod updates for /tests: The tests have their own tests/go.mod file for which we should receive dependency update PRs as well.