### PR TITLE
Retry **every** database error

### DIFF
--- a/pkg/icingadb/cleanup.go
+++ b/pkg/icingadb/cleanup.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"fmt"
 	"github.com/icinga/icingadb/internal"
+	"github.com/icinga/icingadb/pkg/backoff"
 	"github.com/icinga/icingadb/pkg/com"
 	"github.com/icinga/icingadb/pkg/driver"
+	"github.com/icinga/icingadb/pkg/retry"
 	"github.com/icinga/icingadb/pkg/types"
+	"go.uber.org/zap"
 	"time"
 )
 
@@ -41,19 +44,50 @@ func (db *DB) CleanupOlderThan(
 	count uint64, olderThan time.Time, onSuccess ...OnSuccess[struct{}],
 ) (uint64, error) {
 	var counter com.Counter
-	defer db.log(ctx, stmt.Build(db.DriverName(), 0), &counter).Stop()
+	var n int64
+
+	q := db.Rebind(stmt.Build(db.DriverName(), count))
+
+	defer db.log(ctx, q, &counter).Stop()
 
 	for {
-		q := db.Rebind(stmt.Build(db.DriverName(), count))
-		rs, err := db.NamedExecContext(ctx, q, cleanupWhere{
-			EnvironmentId: envId,
-			Time:          types.UnixMilli(olderThan),
-		})
-		if err != nil {
-			return 0, internal.CantPerformQuery(err, q)
-		}
+		err := retry.WithBackoff(
+			ctx,
+			func(ctx context.Context) error {
+				rs, err := db.NamedExecContext(ctx, q, cleanupWhere{
+					EnvironmentId: envId,
+					Time:          types.UnixMilli(olderThan),
+				})
+				if err != nil {
+					return internal.CantPerformQuery(err, q)
+				}
 
-		n, err := rs.RowsAffected()
+				n, err = rs.RowsAffected()
+				if err != nil {
+					return err
+				}
+
+				return nil
+			},
+			retry.Retryable,
+			backoff.NewExponentialWithJitter(1*time.Millisecond, 1*time.Second),
+			retry.Settings{
+				Timeout: time.Minute * 5,
+				OnError: func(_ time.Duration, _ uint64, err, lastErr error) {
+					if lastErr == nil || err.Error() != lastErr.Error() {
+						db.logger.Warnw("Can't execute query. Retrying", zap.Error(err))
+					}
+				},
+				OnSuccess: func(elapsed time.Duration, attempt uint64, lastErr error) {
+					if attempt > 0 {
+						db.logger.Infow("Query retried successfully after error",
+							zap.Duration("after", elapsed),
+							zap.Uint64("attempts", attempt+1),
+							zap.NamedError("recovered_error", lastErr))
+					}
+				},
+			},
+		)
 		if err != nil {
 			return 0, err
 		}

--- a/pkg/icingadb/db.go
+++ b/pkg/icingadb/db.go
@@ -14,6 +14,7 @@ import (
 	"github.com/icinga/icingadb/pkg/utils"
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
+	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 	"reflect"
@@ -338,7 +339,22 @@ func (db *DB) BulkExec(
 						},
 						retry.Retryable,
 						backoff.NewExponentialWithJitter(1*time.Millisecond, 1*time.Second),
-						retry.Settings{},
+						retry.Settings{
+							Timeout: time.Minute * 5,
+							OnError: func(_ time.Duration, _ uint64, err, lastErr error) {
+								if lastErr == nil || err.Error() != lastErr.Error() {
+									db.logger.Warnw("Can't execute query. Retrying", zap.Error(err))
+								}
+							},
+							OnSuccess: func(elapsed time.Duration, attempt uint64, lastErr error) {
+								if attempt > 0 {
+									db.logger.Infow("Query retried successfully after error",
+										zap.Duration("after", elapsed),
+										zap.Uint64("attempts", attempt+1),
+										zap.NamedError("recovered_error", lastErr))
+								}
+							},
+						},
 					)
 				}
 			}(b))
@@ -403,7 +419,22 @@ func (db *DB) NamedBulkExec(
 							},
 							retry.Retryable,
 							backoff.NewExponentialWithJitter(1*time.Millisecond, 1*time.Second),
-							retry.Settings{},
+							retry.Settings{
+								Timeout: time.Minute * 5,
+								OnError: func(_ time.Duration, _ uint64, err, lastErr error) {
+									if lastErr == nil || err.Error() != lastErr.Error() {
+										db.logger.Warnw("Can't execute query. Retrying", zap.Error(err))
+									}
+								},
+								OnSuccess: func(elapsed time.Duration, attempt uint64, lastErr error) {
+									if attempt > 0 {
+										db.logger.Infow("Query retried successfully after error",
+											zap.Duration("after", elapsed),
+											zap.Uint64("attempts", attempt+1),
+											zap.NamedError("recovered_error", lastErr))
+									}
+								},
+							},
 						)
 					}
 				}(b))
@@ -476,7 +507,22 @@ func (db *DB) NamedBulkExecTx(
 							},
 							retry.Retryable,
 							backoff.NewExponentialWithJitter(1*time.Millisecond, 1*time.Second),
-							retry.Settings{},
+							retry.Settings{
+								Timeout: time.Minute * 5,
+								OnError: func(_ time.Duration, _ uint64, err, lastErr error) {
+									if lastErr == nil || err.Error() != lastErr.Error() {
+										db.logger.Warnw("Can't execute query. Retrying", zap.Error(err))
+									}
+								},
+								OnSuccess: func(elapsed time.Duration, attempt uint64, lastErr error) {
+									if attempt > 0 {
+										db.logger.Infow("Query retried successfully after error",
+											zap.Duration("after", elapsed),
+											zap.Uint64("attempts", attempt+1),
+											zap.NamedError("recovered_error", lastErr))
+									}
+								},
+							},
 						)
 					}
 				}(b))

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -8,7 +8,6 @@ import (
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
 	"net"
-	"strings"
 	"syscall"
 	"time"
 )
@@ -141,43 +140,10 @@ func Retryable(err error) bool {
 		return true
 	}
 
-	var e *mysql.MySQLError
-	if errors.As(err, &e) {
-		switch e.Number {
-		case 1053, 1205, 1213, 2006:
-			// 1053: Server shutdown in progress
-			// 1205: Lock wait timeout
-			// 1213: Deadlock found when trying to get lock
-			// 2006: MySQL server has gone away
-			return true
-		default:
-			return false
-		}
-	}
-
-	var pe *pq.Error
-	if errors.As(err, &pe) {
-		switch pe.Code {
-		case "08000", // connection_exception
-			"08006", // connection_failure
-			"08001", // sqlclient_unable_to_establish_sqlconnection
-			"08004", // sqlserver_rejected_establishment_of_sqlconnection
-			"40001", // serialization_failure
-			"40P01", // deadlock_detected
-			"54000", // program_limit_exceeded
-			"55006", // object_in_use
-			"55P03", // lock_not_available
-			"57P01", // admin_shutdown
-			"57P02", // crash_shutdown
-			"57P03", // cannot_connect_now
-			"58000", // system_error
-			"58030", // io_error
-			"XX000": // internal_error
-			return true
-		default:
-			// Class 53 - Insufficient Resources
-			return strings.HasPrefix(string(pe.Code), "53")
-		}
+	var mye *mysql.MySQLError
+	var pqe *pq.Error
+	if errors.As(err, &mye) || errors.As(err, &pqe) {
+		return true
 	}
 
 	return false


### PR DESCRIPTION
This PR introduces several changes to our retention functionality:

* All functions except retention already retry queries, but there is no logging or timeout. Retry will now stop after 5 minutes and failed queries will be logged.
* So far we have kept a list of error codes that should be retried. This doesn't include all the errors that can be retried, and it doesn't even take into account errors that can occur in a database cluster. Instead of going through all possible error codes and checking [1] whether they should be included in the list of retryable errors, **every** database error is now simply retried. Of course, this also means retrying queries that can't be retried at all, but since we now give up after 5 minutes, that's okay.
[1] Based on a short error description from the vendor, it is difficult to tell for every error whether it can actually be retried without the context of when and how exactly such errors are triggered. There are also database clusters that send their own errors using vendor error codes.
* `DELETE` statements from retention are now also retried.

fixes #618
fixes #651
fixes #677