### PR TITLE
MySQL/MariaDB: Use strict SQL mode

### DIFF
--- a/pkg/config/database.go
+++ b/pkg/config/database.go
@@ -61,7 +61,7 @@ func (d *Database) Open(logger *logging.Logger) (*icingadb.DB, error) {
 
 		config.DBName = d.Database
 		config.Timeout = time.Minute
-		config.Params = map[string]string{"sql_mode": "ANSI_QUOTES"}
+		config.Params = map[string]string{"sql_mode": "'TRADITIONAL,ANSI_QUOTES'"}
 
 		tlsConfig, err := d.TlsOptions.MakeConfig(d.Host)
 		if err != nil {


### PR DESCRIPTION
For MySQL (and MariaDB, etc.), in addition to `ANSI_QUOTES` SQL mode, we now also set `TRADITIONAL`, which enables strict mode.

fixes #611
refs #624