### PR TITLE
MySQL/MariaDB: Fix `icingadb_schema.timestamp` not being UNX time

### DIFF
--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -1343,4 +1343,4 @@ CREATE TABLE icingadb_schema (
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 INSERT INTO icingadb_schema (version, timestamp)
-  VALUES (4, CURRENT_TIMESTAMP() * 1000);
+  VALUES (4, UNIX_TIMESTAMP() * 1000);

--- a/schema/mysql/upgrades/1.0.0-rc2.sql
+++ b/schema/mysql/upgrades/1.0.0-rc2.sql
@@ -156,7 +156,7 @@ ALTER TABLE acknowledgement_history
     MODIFY is_persistent enum('n','y') DEFAULT NULL COMMENT 'NULL if ack_set event happened before Icinga DB history recording';
 
 INSERT INTO icingadb_schema (version, timestamp)
-  VALUES (2, CURRENT_TIMESTAMP() * 1000);
+  VALUES (2, UNIX_TIMESTAMP() * 1000);
 
 ALTER TABLE host_state
     MODIFY output longtext DEFAULT NULL,

--- a/schema/mysql/upgrades/1.0.0.sql
+++ b/schema/mysql/upgrades/1.0.0.sql
@@ -288,4 +288,4 @@ INSERT INTO sla_history_downtime
   ON DUPLICATE KEY UPDATE sla_history_downtime.downtime_id = sla_history_downtime.downtime_id;
 
 INSERT INTO icingadb_schema (version, TIMESTAMP)
-  VALUES (3, CURRENT_TIMESTAMP() * 1000);
+  VALUES (3, UNIX_TIMESTAMP() * 1000);

--- a/schema/mysql/upgrades/1.1.1.sql
+++ b/schema/mysql/upgrades/1.1.1.sql
@@ -34,4 +34,4 @@ ALTER TABLE history
 UNLOCK TABLES;
 
 INSERT INTO icingadb_schema (version, timestamp)
-  VALUES (4, CURRENT_TIMESTAMP() * 1000);
+  VALUES (4, UNIX_TIMESTAMP() * 1000);

--- a/schema/mysql/upgrades/1.1.2.sql
+++ b/schema/mysql/upgrades/1.1.2.sql
@@ -1,0 +1,1 @@
+UPDATE icingadb_schema SET timestamp = UNIX_TIMESTAMP(timestamp / 1000) * 1000 WHERE timestamp > 20000000000000000;


### PR DESCRIPTION
We previously incorrectly used `CURRENT_TIMESTAMP()` an alias for `NOW()` which returns the current date and time in the format `YYYY-MM-DD hh:mm:ss` using the session time zone. Since we are using numeric context, the value is stored in the format `YYYYMMDDhhmmss`. But actually we want to set a (millisecond) UNIX timestamp here, so we need to use `UNIX_TIMESTAMP()` instead.

Since the timestamps need to be corrected, there is also a schema upgrade.
