### PR TITLE
Integration tests: don't hard-code MySQL in some tests

### DIFF
--- a/tests/history_test.go
+++ b/tests/history_test.go
@@ -143,7 +143,7 @@ func testHistory(t *testing.T, numNodes int) {
 	}, 15*time.Second, 200*time.Millisecond)
 
 	db, err := sqlx.Connect(rdb.Driver(), rdb.DSN())
-	require.NoError(t, err, "connecting to mysql")
+	require.NoError(t, err, "connecting to database")
 	t.Cleanup(func() { _ = db.Close() })
 
 	client := nodes[0].IcingaClient

--- a/tests/sla_test.go
+++ b/tests/sla_test.go
@@ -18,15 +18,14 @@ import (
 )
 
 func TestSla(t *testing.T) {
-	m := it.MysqlDatabaseT(t)
-	m.ImportIcingaDbSchema()
+	rdb := getDatabase(t)
 
 	r := it.RedisServerT(t)
 	i := it.Icinga2NodeT(t, "master")
 	i.EnableIcingaDb(r)
 	err := i.Reload()
 	require.NoError(t, err, "icinga2 should reload without error")
-	it.IcingaDbInstanceT(t, r, m)
+	it.IcingaDbInstanceT(t, r, rdb)
 
 	client := i.ApiClient()
 
@@ -109,8 +108,8 @@ func TestSla(t *testing.T) {
 
 		assert.Equal(t, 3, len(stateChanges), "there should be three hard state changes")
 
-		db, err := sqlx.Connect("mysql", m.DSN())
-		require.NoError(t, err, "connecting to mysql")
+		db, err := sqlx.Connect(rdb.Driver(), rdb.DSN())
+		require.NoError(t, err, "connecting to database")
 		defer func() { _ = db.Close() }()
 
 		type Row struct {
@@ -248,8 +247,8 @@ func TestSla(t *testing.T) {
 				End   int64 `db:"downtime_end"`
 			}
 
-			db, err := sqlx.Connect("mysql", m.DSN())
-			require.NoError(t, err, "connecting to mysql")
+			db, err := sqlx.Connect(rdb.Driver(), rdb.DSN())
+			require.NoError(t, err, "connecting to database")
 			defer func() { _ = db.Close() }()
 
 			if !o.Fixed {


### PR DESCRIPTION
Some test cases always used a MySQL database as they didn't use the proper function which would respect the `ICINGADB_TESTS_DATABASE_TYPE=pgsql` environment variable. This commit fixes this and updates a similarly left-over error message as well.

## Tests

Excerpts from the GitHub Actions job artifacts (`xzgrep -E 'created (mysql|postgresql) container'`):

### Current `main` branch
https://github.com/Icinga/icingadb/actions/runs/8324491540

#### mysql-debug.log.xz
:heavy_check_mark:  No problem, creates only a MySQL container as expected:
```
{"L":"DEBUG","T":"2024-03-18T09:52:05.779Z","M":"created mysql container","mysql":true,"container-name":"icinga-testing-62f6a821-mysql","container-id":"567aae686d80883b356a20e7340e553a3f97a8c87a94819a0af242f5ac8c7367"}
```

#### pgsql-debug.log.xz
:x:  Unexpectedly creates a MySQL container in addition to the expected PostgreSQL container:
```
{"L":"DEBUG","T":"2024-03-18T09:52:03.145Z","M":"created postgresql container","postgresql":true,"container-name":"icinga-testing-52b5911a-postgresql","container-id":"908a1477ca014e370f55b086c2c5ce3018a74b8eec62c8fdb2254243201953be"}
{"L":"DEBUG","T":"2024-03-18T10:01:04.911Z","M":"created mysql container","mysql":true,"container-name":"icinga-testing-52b5911a-mysql","container-id":"b07bb30672c3403ad71b841afd3633cd1bb5a72522bfd2b81f56bc9d911689bc"}
```

### This PR
https://github.com/Icinga/icingadb/actions/runs/8329451180?pr=709

#### mysql-debug.log.xz
:heavy_check_mark: Still only a MySQL container, so still no problem:
```
{"L":"DEBUG","T":"2024-03-18T15:41:43.526Z","M":"created mysql container","mysql":true,"container-name":"icinga-testing-b8dbc604-mysql","container-id":"6c56e976188d9e0152bbe9e331155e1d4148efd4777f231e84a84c3ac720fe3d"}
```

#### pgsql-debug.log.xz
:heavy_check_mark: Now fixed, no longer creates a MySQL container but just the expected PostgreSQL container:
```
{"L":"DEBUG","T":"2024-03-18T15:41:44.779Z","M":"created postgresql container","postgresql":true,"container-name":"icinga-testing-a4dca8d8-postgresql","container-id":"90f50752265b61a3d2424267a115033a099c21a962c16ae0e01a5cf392745b54"}
```

## Benchmarks

The benchmark doesn't run automatically in GitHub Actions. When running locally, it currently fails with the following error:

```
BenchmarkHistory/100000-Comments
    history_bench_test.go:82: 
        	Error Trace:	/home/jbrost/src/icingadb/tests/history_bench_test.go:82
        	            				/home/jbrost/src/icingadb/tests/history_bench_test.go:93
        	            				/home/jbrost/src/icingadb/tests/history_bench_test.go:22
        	            				/usr/lib/go/src/testing/benchmark.go:193
        	            				/usr/lib/go/src/testing/benchmark.go:215
        	            				/usr/lib/go/src/runtime/asm_amd64.s:1695
        	Error:      	Received unexpected error:
        	            	redis: got 20 elements in XINFO STREAM reply,wanted 14
        	Test:       	BenchmarkHistory/100000-Comments
        	Messages:   	XINFO should not fail
--- FAIL: BenchmarkHistory/100000-Comments
```

That's an error from the Redis client library we use as it fails to parse a protocol message. I believe this happens due to the following change to [`XINFO STREAM` command in Redis 7.0](https://redis.io/commands/xinfo-stream/):

> Starting with Redis version 7.0.0: Added the max-deleted-entry-id, entries-added, recorded-first-entry-id, entries-read and lag fields

When running with `ICINGA_TESTING_REDIS_IMAGE=redis:6`, this error doesn't happen, the benchmark still doesn't work though, now it just stays at all entries pending in the stream, but that's doesn't seem to be a PostgreSQL-specific problem as it happens on MySQL as well. So the PR should fix the hard-coded MySQL problem, but a different problem remains.

We currently use an outdated version of `go-redis` as the new version wasn't picked up by depandabot. I've created #708 for that.