### PR TITLE
`history.Sync`: Don't operate on closed channel

### DIFF
--- a/pkg/icingadb/history/sync.go
+++ b/pkg/icingadb/history/sync.go
@@ -144,7 +144,11 @@ func (s Sync) deleteFromRedis(ctx context.Context, key string, input <-chan redi
 	stream := "icinga:history:stream:" + key
 	for {
 		select {
-		case bulk := <-bulks:
+		case bulk, ok := <-bulks:
+			if !ok {
+				return nil
+			}
+
 			ids := make([]string, len(bulk))
 			for i := range bulk {
 				ids[i] = bulk[i].ID


### PR DESCRIPTION
## Before

```diff
diff --git a/pkg/icingadb/history/sync.go b/pkg/icingadb/history/sync.go
index 4be0e71..fb31d31 100644
--- a/pkg/icingadb/history/sync.go
+++ b/pkg/icingadb/history/sync.go
@@ -140,7 +140,9 @@ func (s Sync) deleteFromRedis(ctx context.Context, key string, input <-chan redi
                }
        }).Stop()
 
-       bulks := com.Bulk(ctx, input, s.redis.Options.HScanCount, com.NeverSplit[redis.XMessage])
+       justKidding := make(chan redis.XMessage)
+       close(justKidding)
+       bulks := com.Bulk(ctx, justKidding, s.redis.Options.HScanCount, com.NeverSplit[redis.XMessage])
        stream := "icinga:history:stream:" + key
        for {
                select {
```
&#x2193;
```go
2024-03-28T15:00:22.430+0100    FATAL   main    ERR wrong number of arguments for 'xdel' command
can't perform "[xdel icinga:history:stream:flapping]"
github.com/icinga/icingadb/pkg/icingaredis.WrapCmdErr
        /Users/yhabteab/Workspace/go/icingadb/pkg/icingaredis/utils.go:121
github.com/icinga/icingadb/pkg/icingadb/history.Sync.deleteFromRedis
        /Users/yhabteab/Workspace/go/icingadb/pkg/icingadb/history/sync.go:157
github.com/icinga/icingadb/pkg/icingadb/history.Sync.Sync.func3
        /Users/yhabteab/Workspace/go/icingadb/pkg/icingadb/history/sync.go:96
golang.org/x/sync/errgroup.(*Group).Go.func1
        /Users/yhabteab/go/pkg/mod/golang.org/x/sync@v0.6.0/errgroup/errgroup.go:78
runtime.goexit
        /opt/homebrew/Cellar/go/1.22.1/libexec/src/runtime/asm_arm64.s:1222
exit status 1
```

### After

*No crash*

fixes #713 