### PR TITLE
Register mysql default logger prior to `mysql#NewConfig()`

### DIFF
--- a/pkg/config/database.go
+++ b/pkg/config/database.go
@@ -42,6 +42,7 @@ func (d *Database) Open(logger *logging.Logger) (*icingadb.DB, error) {
 
 		config.User = d.User
 		config.Passwd = d.Password
+		config.Logger = icingadb.MysqlFuncLogger(logger.Debug)
 
 		if d.isUnixAddr() {
 			config.Net = "unix"
@@ -70,8 +71,6 @@ func (d *Database) Open(logger *logging.Logger) (*icingadb.DB, error) {
 				return nil, errors.Wrap(err, "can't register TLS config")
 			}
 		}
-
-		_ = mysql.SetLogger(icingadb.MysqlFuncLogger(logger.Debug))
 
 		c, err := mysql.NewConnector(config)
 		if err != nil {


### PR DESCRIPTION
**Before:**
```bash
2024-04-08T13:55:58.621+0200    WARN    database        Can't connect to database. Retrying     {"error": "driver: bad connection"}
2024-04-08T13:56:00.294+0200    WARN    database        Can't connect to database. Retrying     {"error": "dial tcp [::1]:3306: connect: connection refused"}
2024-04-08T13:56:40.352+0200    INFO    database        Reconnected to database {"after": "41.737475334s", "attempts": 10}
[mysql] 2024/04/08 14:03:19 connection.go:49: closing bad idle connection: EOF
[mysql] 2024/04/08 14:03:19 connection.go:49: closing bad idle connection: EOF
```

**After:**
```bash
2024-04-08T14:41:53.032+0200    DEBUG   database        [unexpected EOF]
2024-04-08T14:41:53.272+0200    DEBUG   database        [unexpected EOF]
2024-04-08T14:41:53.272+0200    WARN    database        Can't connect to database. Retrying     {"error": "driver: bad connection"}
2024-04-08T14:41:53.353+0200    DEBUG   database        [unexpected EOF]
2024-04-08T14:41:53.581+0200    DEBUG   database        [unexpected EOF]
2024-04-08T14:41:53.878+0200    DEBUG   database        [unexpected EOF]
...
2024-04-08T14:46:12.751+0200    DEBUG   database        [closing bad idle connection:  EOF]
2024-04-08T14:46:12.751+0200    DEBUG   database        [closing bad idle connection:  EOF]
2024-04-08T14:46:12.751+0200    DEBUG   database        [closing bad idle connection:  EOF]
2024-04-08T14:46:12.751+0200    DEBUG   database        [closing bad idle connection:  EOF]
2024-04-08T14:46:12.753+0200    DEBUG   database        [closing bad idle connection:  EOF]
```