### PR TITLE
Remove deprecated io/ioutil package references

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -7,7 +7,6 @@ import (
 	"github.com/goccy/go-yaml"
 	"github.com/jessevdk/go-flags"
 	"github.com/pkg/errors"
-	"io/ioutil"
 	"os"
 )
 
@@ -118,7 +117,7 @@ func (t *TLS) MakeConfig(serverName string) (*tls.Config, error) {
 	if t.Insecure {
 		tlsConfig.InsecureSkipVerify = true
 	} else if t.Ca != "" {
-		raw, err := ioutil.ReadFile(t.Ca)
+		raw, err := os.ReadFile(t.Ca)
 		if err != nil {
 			return nil, errors.Wrap(err, "can't read CA file")
 		}

--- a/pkg/icingadb/objectpacker/objectpacker.go
+++ b/pkg/icingadb/objectpacker/objectpacker.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"github.com/pkg/errors"
 	"io"
-	"io/ioutil"
 	"reflect"
 	"sort"
 )
@@ -102,7 +101,7 @@ func packValue(in reflect.Value, out io.Writer) error {
 		// If there aren't any values to pack, ...
 		if l < 1 {
 			// ... create one and pack it - panics on disallowed type.
-			_ = packValue(reflect.Zero(in.Type().Elem()), ioutil.Discard)
+			_ = packValue(reflect.Zero(in.Type().Elem()), io.Discard)
 		}
 
 		return nil
@@ -140,13 +139,13 @@ func packValue(in reflect.Value, out io.Writer) error {
 						packedKey = key.Slice(0, key.Len()).Interface().([]byte)
 					} else {
 						// Not just stringify the key (below), but also pack it (here) - panics on disallowed type.
-						_ = packValue(iter.Key(), ioutil.Discard)
+						_ = packValue(iter.Key(), io.Discard)
 
 						packedKey = []byte(fmt.Sprint(key.Interface()))
 					}
 				} else {
 					// Not just stringify the key (below), but also pack it (here) - panics on disallowed type.
-					_ = packValue(iter.Key(), ioutil.Discard)
+					_ = packValue(iter.Key(), io.Discard)
 
 					packedKey = []byte(fmt.Sprint(key.Interface()))
 				}
@@ -176,8 +175,8 @@ func packValue(in reflect.Value, out io.Writer) error {
 			typ := in.Type()
 
 			// ... create one and pack it - panics on disallowed type.
-			_ = packValue(reflect.Zero(typ.Key()), ioutil.Discard)
-			_ = packValue(reflect.Zero(typ.Elem()), ioutil.Discard)
+			_ = packValue(reflect.Zero(typ.Key()), io.Discard)
+			_ = packValue(reflect.Zero(typ.Elem()), io.Discard)
 		}
 
 		return nil
@@ -186,7 +185,7 @@ func packValue(in reflect.Value, out io.Writer) error {
 			err := packValue(reflect.Value{}, out)
 
 			// Create a fictive referenced value and pack it - panics on disallowed type.
-			_ = packValue(reflect.Zero(in.Type().Elem()), ioutil.Discard)
+			_ = packValue(reflect.Zero(in.Type().Elem()), io.Discard)
 
 			return err
 		} else {

--- a/tests/history_test.go
+++ b/tests/history_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
-	"io/ioutil"
+	"io"
 	"math"
 	"net/http"
 	"sort"
@@ -717,7 +717,7 @@ func processCheckResult(t *testing.T, client *utils.Icinga2Client, hostname stri
 	response, err := client.PostJson("/v1/actions/process-check-result", bytes.NewBuffer(reqBody))
 	require.NoError(t, err, "process-check-result")
 	if !assert.Equal(t, 200, response.StatusCode, "process-check-result") {
-		body, err := ioutil.ReadAll(response.Body)
+		body, err := io.ReadAll(response.Body)
 		require.NoError(t, err, "reading process-check-result response")
 		it.Logger(t).Error("process-check-result", zap.ByteString("api-response", body))
 		t.FailNow()


### PR DESCRIPTION
The io/ioutil package is deprecated since Go 1.16. All its functions were moved to either the io or os package.