### PR TITLE
Unify notation of `n * time.Duration`

### DIFF
--- a/pkg/backoff/backoff.go
+++ b/pkg/backoff/backoff.go
@@ -14,10 +14,10 @@ type Backoff func(uint64) time.Duration
 // It panics if min >= max.
 func NewExponentialWithJitter(min, max time.Duration) Backoff {
 	if min <= 0 {
-		min = time.Millisecond * 100
+		min = 100 * time.Millisecond
 	}
 	if max <= 0 {
-		max = time.Second * 10
+		max = 10 * time.Second
 	}
 	if min >= max {
 		panic("max must be larger than min")

--- a/pkg/icingadb/driver.go
+++ b/pkg/icingadb/driver.go
@@ -53,7 +53,7 @@ func (c RetryConnector) Connect(ctx context.Context) (driver.Conn, error) {
 			return
 		},
 		retry.Retryable,
-		backoff.NewExponentialWithJitter(time.Millisecond*128, time.Minute*1),
+		backoff.NewExponentialWithJitter(128*time.Millisecond, 1*time.Minute),
 		retry.Settings{
 			Timeout: retry.DefaultTimeout,
 			OnRetryableError: func(_ time.Duration, _ uint64, err, lastErr error) {

--- a/pkg/icingadb/ha.go
+++ b/pkg/icingadb/ha.go
@@ -384,7 +384,7 @@ func (h *HA) realize(
 			return nil
 		},
 		retry.Retryable,
-		backoff.NewExponentialWithJitter(time.Millisecond*256, time.Second*3),
+		backoff.NewExponentialWithJitter(256*time.Millisecond, 3*time.Second),
 		retry.Settings{
 			// Intentionally no timeout is set, as we use a context with a deadline.
 			OnRetryableError: func(_ time.Duration, attempt uint64, err, lastErr error) {

--- a/pkg/icingaredis/heartbeat.go
+++ b/pkg/icingaredis/heartbeat.go
@@ -97,7 +97,7 @@ func (h *Heartbeat) controller(ctx context.Context) {
 	// Message producer loop.
 	g.Go(func() error {
 		// We expect heartbeats every second but only read them every 3 seconds.
-		throttle := time.NewTicker(time.Second * 3)
+		throttle := time.NewTicker(3 * time.Second)
 		defer throttle.Stop()
 
 		for id := "$"; ; {


### PR DESCRIPTION
Merge after #698 because of https://github.com/Icinga/icingadb/pull/738#issuecomment-2049074001.