### PR TITLE
Retry `io.EOF` error

### DIFF
--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -7,6 +7,7 @@ import (
 	"github.com/icinga/icingadb/pkg/backoff"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
+	"io"
 	"net"
 	"syscall"
 	"time"
@@ -173,6 +174,9 @@ func Retryable(err error) bool {
 		return true
 	}
 	if errors.Is(err, syscall.EPIPE) {
+		return true
+	}
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
 		return true
 	}
 


### PR DESCRIPTION
Otherwise, Icinga DB will crash immediately!

```bash
2024-04-11T09:08:45.502+0200    INFO    history-sync    Synced 104 notification history items
2024-04-11T09:08:47.806+0200    WARN    database        Can't connect to database. Retrying     {"error": "pq: the database system is shutting down"}
2024-04-11T09:08:47.895+0200    WARN    database        Can't connect to database. Retrying     {"error": "read tcp 127.0.0.1:53259->127.0.0.1:5432: read: connection reset by peer"}
2024-04-11T09:08:48.095+0200    WARN    database        Can't connect to database. Retrying     {"error": "read tcp 127.0.0.1:53260->127.0.0.1:5432: read: connection reset by peer"}
2024-04-11T09:08:48.236+0200    FATAL   main    EOF
can't retry
github.com/icinga/icingadb/pkg/retry.WithBackoff
        /Users/yhabteab/Workspace/go/icingadb/pkg/retry/retry.go:81
github.com/icinga/icingadb/pkg/icingadb.RetryConnector.Connect
        /Users/yhabteab/Workspace/go/icingadb/pkg/icingadb/driver.go:42
database/sql.(*DB).conn
        /opt/homebrew/Cellar/go/1.22.1/libexec/src/database/sql/sql.go:1415
database/sql.(*DB).exec
        /opt/homebrew/Cellar/go/1.22.1/libexec/src/database/sql/sql.go:1679
database/sql.(*DB).ExecContext.func1
        /opt/homebrew/Cellar/go/1.22.1/libexec/src/database/sql/sql.go:1662
database/sql.(*DB).retry
        /opt/homebrew/Cellar/go/1.22.1/libexec/src/database/sql/sql.go:1573
database/sql.(*DB).ExecContext
        /opt/homebrew/Cellar/go/1.22.1/libexec/src/database/sql/sql.go:1661
github.com/jmoiron/sqlx.NamedExecContext
        /Users/yhabteab/Workspace/go/pkg/mod/github.com/jmoiron/sqlx@v1.3.5/named_context.go:131
github.com/jmoiron/sqlx.(*DB).NamedExecContext
        /Users/yhabteab/Workspace/go/pkg/mod/github.com/jmoiron/sqlx@v1.3.5/sqlx_context.go:134
github.com/icinga/icingadb/pkg/icingadb.(*DB).NamedBulkExec.func1.(*DB).NamedBulkExec.func1.1.2.1
        /Users/yhabteab/Workspace/go/icingadb/pkg/icingadb/db.go:398
github.com/icinga/icingadb/pkg/retry.WithBackoff
        /Users/yhabteab/Workspace/go/icingadb/pkg/retry/retry.go:59
github.com/icinga/icingadb/pkg/icingadb.(*DB).NamedBulkExec.func1.(*DB).NamedBulkExec.func1.1.2
        /Users/yhabteab/Workspace/go/icingadb/pkg/icingadb/db.go:395
golang.org/x/sync/errgroup.(*Group).Go.func1
        /Users/yhabteab/Workspace/go/pkg/mod/golang.org/x/sync@v0.7.0/errgroup/errgroup.go:78
runtime.goexit
        /opt/homebrew/Cellar/go/1.22.1/libexec/src/runtime/asm_arm64.s:1222
can't connect to database
github.com/icinga/icingadb/pkg/icingadb.RetryConnector.Connect
        /Users/yhabteab/Workspace/go/icingadb/pkg/icingadb/driver.go:42
database/sql.(*DB).conn
        /opt/homebrew/Cellar/go/1.22.1/libexec/src/database/sql/sql.go:1415
database/sql.(*DB).exec
        /opt/homebrew/Cellar/go/1.22.1/libexec/src/database/sql/sql.go:1679
database/sql.(*DB).ExecContext.func1
        /opt/homebrew/Cellar/go/1.22.1/libexec/src/database/sql/sql.go:1662
database/sql.(*DB).retry
        /opt/homebrew/Cellar/go/1.22.1/libexec/src/database/sql/sql.go:1573
database/sql.(*DB).ExecContext
        /opt/homebrew/Cellar/go/1.22.1/libexec/src/database/sql/sql.go:1661
github.com/jmoiron/sqlx.NamedExecContext
        /Users/yhabteab/Workspace/go/pkg/mod/github.com/jmoiron/sqlx@v1.3.5/named_context.go:131
github.com/jmoiron/sqlx.(*DB).NamedExecContext
        /Users/yhabteab/Workspace/go/pkg/mod/github.com/jmoiron/sqlx@v1.3.5/sqlx_context.go:134
github.com/icinga/icingadb/pkg/icingadb.(*DB).NamedBulkExec.func1.(*DB).NamedBulkExec.func1.1.2.1
        /Users/yhabteab/Workspace/go/icingadb/pkg/icingadb/db.go:398
github.com/icinga/icingadb/pkg/retry.WithBackoff
        /Users/yhabteab/Workspace/go/icingadb/pkg/retry/retry.go:59
github.com/icinga/icingadb/pkg/icingadb.(*DB).NamedBulkExec.func1.(*DB).NamedBulkExec.func1.1.2
        /Users/yhabteab/Workspace/go/icingadb/pkg/icingadb/db.go:395
golang.org/x/sync/errgroup.(*Group).Go.func1
        /Users/yhabteab/Workspace/go/pkg/mod/golang.org/x/sync@v0.7.0/errgroup/errgroup.go:78
runtime.goexit
        /opt/homebrew/Cellar/go/1.22.1/libexec/src/runtime/asm_arm64.s:1222
can't perform "INSERT INTO \"state_history\" (\"event_time\", \"previous_hard_state\", \"endpoint_id\", \"id\", \"service_id\", \"soft_state\", \"previous_soft_state\", \"scheduling_source\", \"host_id\", \"state_type\", \"max_check_attempts\", \"check_source\", \"object_type\", \"environment_id\", \"hard_state\", \"check_attempt\", \"output\", \"long_output\") VALUES (:event_time,:previous_hard_state,:endpoint_id,:id,:service_id,:soft_state,:previous_soft_state,:scheduling_source,:host_id,:state_type,:max_check_attempts,:check_source,:object_type,:environment_id,:hard_state,:check_attempt,:output,:long_output) ON CONFLICT ON CONSTRAINT pk_state_history DO UPDATE SET \"id\" = EXCLUDED.\"id\""
github.com/icinga/icingadb/internal.CantPerformQuery
        /Users/yhabteab/Workspace/go/icingadb/internal/internal.go:30
github.com/icinga/icingadb/pkg/icingadb.(*DB).NamedBulkExec.func1.(*DB).NamedBulkExec.func1.1.2.1
        /Users/yhabteab/Workspace/go/icingadb/pkg/icingadb/db.go:400
github.com/icinga/icingadb/pkg/retry.WithBackoff
        /Users/yhabteab/Workspace/go/icingadb/pkg/retry/retry.go:59
github.com/icinga/icingadb/pkg/icingadb.(*DB).NamedBulkExec.func1.(*DB).NamedBulkExec.func1.1.2
        /Users/yhabteab/Workspace/go/icingadb/pkg/icingadb/db.go:395
golang.org/x/sync/errgroup.(*Group).Go.func1
        /Users/yhabteab/Workspace/go/pkg/mod/golang.org/x/sync@v0.7.0/errgroup/errgroup.go:78
runtime.goexit
        /opt/homebrew/Cellar/go/1.22.1/libexec/src/runtime/asm_arm64.s:1222
can't retry
github.com/icinga/icingadb/pkg/retry.WithBackoff
        /Users/yhabteab/Workspace/go/icingadb/pkg/retry/retry.go:81
github.com/icinga/icingadb/pkg/icingadb.(*DB).NamedBulkExec.func1.(*DB).NamedBulkExec.func1.1.2
        /Users/yhabteab/Workspace/go/icingadb/pkg/icingadb/db.go:395
golang.org/x/sync/errgroup.(*Group).Go.func1
        /Users/yhabteab/Workspace/go/pkg/mod/golang.org/x/sync@v0.7.0/errgroup/errgroup.go:78
runtime.goexit
        /opt/homebrew/Cellar/go/1.22.1/libexec/src/runtime/asm_arm64.s:1222
exit status 1
```

refs #698 