### PR TITLE
utils: Remove unused functions, stdlib replacements

### DIFF
--- a/pkg/config/redis.go
+++ b/pkg/config/redis.go
@@ -8,7 +8,6 @@ import (
 	"github.com/icinga/icingadb/pkg/icingaredis"
 	"github.com/icinga/icingadb/pkg/logging"
 	"github.com/icinga/icingadb/pkg/retry"
-	"github.com/icinga/icingadb/pkg/utils"
 	"github.com/pkg/errors"
 	"github.com/redis/go-redis/v9"
 	"go.uber.org/zap"
@@ -64,7 +63,7 @@ func (r *Redis) NewClient(logger *logging.Logger) (*icingaredis.Client, error) {
 	c := redis.NewClient(options)
 
 	opts := c.Options()
-	opts.PoolSize = utils.MaxInt(32, opts.PoolSize)
+	opts.PoolSize = max(32, opts.PoolSize)
 	opts.MaxRetries = opts.PoolSize + 1 // https://github.com/go-redis/redis/issues/1737
 	c = redis.NewClient(opts)
 

--- a/pkg/types/unix_milli.go
+++ b/pkg/types/unix_milli.go
@@ -6,13 +6,12 @@ import (
 	"encoding"
 	"encoding/json"
 	"github.com/icinga/icingadb/internal"
-	"github.com/icinga/icingadb/pkg/utils"
 	"github.com/pkg/errors"
 	"strconv"
 	"time"
 )
 
-// UnixMilli is a nullable millisecond UNIX timestamp in databases and JSON.
+// UnixMilli is a nullable millisecond Unix timestamp in databases and JSON.
 type UnixMilli time.Time
 
 // Time returns the time.Time conversion of UnixMilli.
@@ -37,7 +36,7 @@ func (t *UnixMilli) UnmarshalText(text []byte) error {
 		return internal.CantParseFloat64(err, string(text))
 	}
 
-	*t = UnixMilli(utils.FromUnixMilli(int64(parsed)))
+	*t = UnixMilli(time.UnixMilli(int64(parsed)))
 	return nil
 }
 
@@ -52,8 +51,7 @@ func (t *UnixMilli) UnmarshalJSON(data []byte) error {
 	if err != nil {
 		return internal.CantParseFloat64(err, string(data))
 	}
-	tt := utils.FromUnixMilli(int64(ms))
-	*t = UnixMilli(tt)
+	*t = UnixMilli(time.UnixMilli(int64(ms)))
 
 	return nil
 }
@@ -69,8 +67,7 @@ func (t *UnixMilli) Scan(src interface{}) error {
 	if !ok {
 		return errors.Errorf("bad int64 type assertion from %#v", src)
 	}
-	tt := utils.FromUnixMilli(v)
-	*t = UnixMilli(tt)
+	*t = UnixMilli(time.UnixMilli(v))
 
 	return nil
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,27 +4,15 @@ import (
 	"context"
 	"crypto/sha1"
 	"fmt"
-	"github.com/go-sql-driver/mysql"
 	"github.com/icinga/icingadb/pkg/contracts"
-	"github.com/lib/pq"
 	"github.com/pkg/errors"
 	"golang.org/x/exp/utf8string"
-	"math"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 	"unicode"
 )
-
-// FromUnixMilli creates and returns a time.Time value
-// from the given milliseconds since the Unix epoch ms.
-func FromUnixMilli(ms int64) time.Time {
-	sec, dec := math.Modf(float64(ms) / 1e3)
-
-	return time.Unix(int64(sec), int64(dec*(1e9)))
-}
 
 // Name returns the declared name of type t.
 // Name is used in combination with Key
@@ -49,20 +37,6 @@ func TableName(t interface{}) string {
 // with an additional separator in front of each original upper case letter.
 func Key(name string, sep byte) string {
 	return ConvertCamelCase(name, unicode.LowerCase, sep)
-}
-
-// Timed calls the given callback with the time that has elapsed since the start.
-//
-// Timed should be installed by defer:
-//
-//	func TimedExample(logger *zap.SugaredLogger) {
-//		defer utils.Timed(time.Now(), func(elapsed time.Duration) {
-//			logger.Debugf("Executed job in %s", elapsed)
-//		})
-//		job()
-//	}
-func Timed(start time.Time, callback func(elapsed time.Duration)) {
-	callback(time.Since(start))
 }
 
 // BatchSliceOfStrings groups the given keys into chunks of size count and streams them into a returned channel.
@@ -113,29 +87,6 @@ func Checksum(data interface{}) []byte {
 // Fatal panics with the given error.
 func Fatal(err error) {
 	panic(err)
-}
-
-// IsDeadlock returns whether the given error signals serialization failure.
-func IsDeadlock(err error) bool {
-	var e *mysql.MySQLError
-	if errors.As(err, &e) {
-		switch e.Number {
-		case 1205, 1213:
-			return true
-		default:
-			return false
-		}
-	}
-
-	var pe *pq.Error
-	if errors.As(err, &pe) {
-		switch pe.Code {
-		case "40001", "40P01":
-			return true
-		}
-	}
-
-	return false
 }
 
 var ellipsis = utf8string.NewString("...")
@@ -197,15 +148,6 @@ func AppName() string {
 	}
 
 	return filepath.Base(exe)
-}
-
-// MaxInt returns the larger of the given integers.
-func MaxInt(x, y int) int {
-	if x > y {
-		return x
-	}
-
-	return y
 }
 
 // JoinHostPort is like its equivalent in net., but handles UNIX sockets as well.


### PR DESCRIPTION
The rationale for this change was mainly to keep at least some of the changes I made in #578. And of course tidying up the codebase a little.

- FromUnixMilli: replaced by time.UnixMilli, Go 1.17
- Timed: unused since bd23f17eda4c0d6155ba38b9193134968fb56351
- IsDeadlock: unused since 943133a4ac7ebe3263fb85a5c4c78f6102c20cf0
- MaxInt: replaced by the max builtin, Go 1.21