### PR TITLE
setGaleraOpts(): execute SET SESSION wsrep_sync_wait directly

### DIFF
--- a/pkg/config/database.go
+++ b/pkg/config/database.go
@@ -189,27 +189,15 @@ func unknownDbType(t string) error {
 //
 // https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_sync_wait
 func setGaleraOpts(ctx context.Context, conn driver.Conn, wsrepSyncWait int64) error {
-	const galeraOpts = "SET SESSION wsrep_sync_wait=?"
+	galeraOpts := "SET SESSION wsrep_sync_wait=" + strconv.FormatInt(wsrepSyncWait, 10)
 
-	stmt, err := conn.(driver.ConnPrepareContext).PrepareContext(ctx, galeraOpts)
+	_, err := conn.(driver.ExecerContext).ExecContext(ctx, galeraOpts, nil)
 	if err != nil {
 		if errors.Is(err, &mysql.MySQLError{Number: 1193}) { // Unknown system variable
 			return nil
 		}
 
-		return errors.Wrap(err, "cannot prepare "+galeraOpts)
-	}
-	// This is just for an unexpected exit and any returned error can safely be ignored and in case
-	// of the normal function exit, the stmt is closed manually, and its error is handled gracefully.
-	defer func() { _ = stmt.Close() }()
-
-	_, err = stmt.(driver.StmtExecContext).ExecContext(ctx, []driver.NamedValue{{Value: wsrepSyncWait}})
-	if err != nil {
 		return errors.Wrap(err, "cannot execute "+galeraOpts)
-	}
-
-	if err = stmt.Close(); err != nil {
-		return errors.Wrap(err, "cannot close prepared statement "+galeraOpts)
 	}
 
 	return nil


### PR DESCRIPTION
to save extra roundtrips for preparing and closing a statement.

* Idea (c) @glbyers #750

## Test

```
000001F4  1e 00 00 00 03 53 45 54  20 53 45 53 53 49 4f 4e   .....SET  SESSION
00000204  20 77 73 72 65 70 5f 73  79 6e 63 5f 77 61 69 74    wsrep_s ync_wait
00000214  3d 37                                              =7
    00000231  32 00 00 01 ff a9 04 23  48 59 30 30 30 55 6e 6b   2......# HY000Unk
    00000241  6e 6f 77 6e 20 73 79 73  74 65 6d 20 76 61 72 69   nown sys tem vari
    00000251  61 62 6c 65 20 27 77 73  72 65 70 5f 73 79 6e 63   able 'ws rep_sync
    00000261  5f 77 61 69 74 27                                  _wait'
00000216  01 00 00 00 0e                                     .....
    00000267  07 00 00 01 00 00 00 02  00 01 00                  ........ ...
0000021B  3d 00 00 00 03 53 45 4c  45 43 54 20 76 65 72 73   =....SEL ECT vers
0000022B  69 6f 6e 20 46 52 4f 4d  20 69 63 69 6e 67 61 64   ion FROM  icingad
0000023B  62 5f 73 63 68 65 6d 61  20 4f 52 44 45 52 20 42   b_schema  ORDER B
0000024B  59 20 69 64 20 44 45 53  43 20 4c 49 4d 49 54 20   Y id DES C LIMIT 
0000025B  31                                                 1
```

👍