### PR TITLE
GHA: Docker: don't run on support/* branches

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -5,7 +5,6 @@ on:
   push:
     branches:
       - main
-      - 'support/*'
   release:
     types:
       - published


### PR DESCRIPTION
PRs to them are already covered and we don't need support* image tags.