### PR TITLE
icingadb-migrate: Mitigate NULL names in {comment,downtime}_query

### DIFF
--- a/cmd/icingadb-migrate/embed/comment_query.sql
+++ b/cmd/icingadb-migrate/embed/comment_query.sql
@@ -2,7 +2,9 @@ SELECT ch.commenthistory_id, UNIX_TIMESTAMP(ch.entry_time) entry_time,
   ch.entry_time_usec, ch.entry_type, ch.author_name, ch.comment_data, ch.is_persistent,
   COALESCE(UNIX_TIMESTAMP(ch.expiration_time), 0) expiration_time,
   COALESCE(UNIX_TIMESTAMP(ch.deletion_time), 0) deletion_time,
-  ch.deletion_time_usec, ch.name, o.objecttype_id, o.name1, COALESCE(o.name2, '') name2
+  ch.deletion_time_usec,
+  COALESCE(ch.name, CONCAT(o.name1, '!', COALESCE(o.name2, ''), '!', ch.commenthistory_id, '-', ch.object_id)) name,
+  o.objecttype_id, o.name1, COALESCE(o.name2, '') name2
 FROM icinga_commenthistory ch USE INDEX (PRIMARY)
 INNER JOIN icinga_objects o ON o.object_id=ch.object_id
 WHERE ch.commenthistory_id BETWEEN :fromid AND :toid

--- a/cmd/icingadb-migrate/embed/downtime_query.sql
+++ b/cmd/icingadb-migrate/embed/downtime_query.sql
@@ -3,8 +3,9 @@ SELECT dh.downtimehistory_id, UNIX_TIMESTAMP(dh.entry_time) entry_time, dh.autho
   COALESCE(UNIX_TIMESTAMP(dh.scheduled_end_time), 0) scheduled_end_time, dh.was_started,
   COALESCE(UNIX_TIMESTAMP(dh.actual_start_time), 0) actual_start_time, dh.actual_start_time_usec,
   COALESCE(UNIX_TIMESTAMP(dh.actual_end_time), 0) actual_end_time, dh.actual_end_time_usec, dh.was_cancelled,
-  COALESCE(UNIX_TIMESTAMP(dh.trigger_time), 0) trigger_time, dh.name, o.objecttype_id,
-  o.name1, COALESCE(o.name2, '') name2, COALESCE(sd.name, '') triggered_by
+  COALESCE(UNIX_TIMESTAMP(dh.trigger_time), 0) trigger_time,
+  COALESCE(dh.name, CONCAT(o.name1, '!', COALESCE(o.name2, ''), '!', dh.downtimehistory_id, '-', dh.object_id)) name,
+  o.objecttype_id, o.name1, COALESCE(o.name2, '') name2, COALESCE(sd.name, '') triggered_by
 FROM icinga_downtimehistory dh USE INDEX (PRIMARY)
 INNER JOIN icinga_objects o ON o.object_id=dh.object_id
 LEFT JOIN icinga_scheduleddowntime sd ON sd.scheduleddowntime_id=dh.triggered_by_id


### PR DESCRIPTION
Historical data from an older Icinga 2 installation contained NULL values for the name column in some rows of the icinga_commenthistory and icinga_downtimehistory tables.

Normally this field contains something like
${name1}!${name2}!${unique_value} where the $unique_value is based on a timestamp for older entries and a UUID for newer ones. For a concrete example, this could be "host.example.com!ping6!123…".

Unfortunately, using an empty string for these NULL values will cause an error later because the new primary key will be calculated based on it. Therefore, a new deterministic name is generated based on the primary keys and the known name1 and name2 values.

Closes #766.