### PR TITLE
icingadb-migrate: Verify env ID length

### DIFF
--- a/cmd/icingadb-migrate/main.go
+++ b/cmd/icingadb-migrate/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/sha1"
 	"database/sql"
 	_ "embed"
 	"encoding/hex"
@@ -71,8 +72,8 @@ func main() {
 		_, _ = fmt.Fprintf(os.Stderr, "bad env ID: %s\n", err.Error())
 		os.Exit(2)
 	}
-	if len(envId) != 20 {
-		_, _ = fmt.Fprintf(os.Stderr, "bad env ID: must be 20 bytes long, has %d bytes\n", len(envId))
+	if len(envId) != sha1.Size {
+		_, _ = fmt.Fprintf(os.Stderr, "bad env ID: must be %d bytes long, has %d bytes\n", sha1.Size, len(envId))
 		os.Exit(2)
 	}
 

--- a/cmd/icingadb-migrate/main.go
+++ b/cmd/icingadb-migrate/main.go
@@ -71,6 +71,10 @@ func main() {
 		_, _ = fmt.Fprintf(os.Stderr, "bad env ID: %s\n", err.Error())
 		os.Exit(2)
 	}
+	if len(envId) != 20 {
+		_, _ = fmt.Fprintf(os.Stderr, "bad env ID: must be 20 bytes long, has %d bytes\n", len(envId))
+		os.Exit(2)
+	}
 
 	defer func() { _ = log.Sync() }()
 


### PR DESCRIPTION
An env ID with the wrong length, either due to a copy-paste error or human error during testing, results in a SQL CHECK CONSTRAINT violation that is retried multiple times until it finally fails.