### PR TITLE
cmd/icingadb-migrate: replace magic number 20 with sha1.Size

### DIFF
--- a/cmd/icingadb-migrate/main.go
+++ b/cmd/icingadb-migrate/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"crypto/sha1"
 	"database/sql"
 	_ "embed"
 	"encoding/hex"
@@ -71,8 +72,8 @@ func main() {
 		_, _ = fmt.Fprintf(os.Stderr, "bad env ID: %s\n", err.Error())
 		os.Exit(2)
 	}
-	if len(envId) != 20 {
-		_, _ = fmt.Fprintf(os.Stderr, "bad env ID: must be 20 bytes long, has %d bytes\n", len(envId))
+	if len(envId) != sha1.Size {
+		_, _ = fmt.Fprintf(os.Stderr, "bad env ID: must be %d bytes long, has %d bytes\n", sha1.Size, len(envId))
 		os.Exit(2)
 	}
 


### PR DESCRIPTION
## Test

```
bad env ID: must be 20 bytes long, has 21 bytes
```

👍