### PR TITLE
HA#realize(): avoid deadlocks via exclusive locking, i.e. SELECT ... FOR UPDATE

### DIFF
--- a/pkg/icingadb/ha.go
+++ b/pkg/icingadb/ha.go
@@ -291,9 +291,11 @@ func (h *HA) realize(
 
 			if h.db.DriverName() == database.MySQL {
 				// The RDBMS may actually be a Percona XtraDB Cluster which doesn't
-				// support serializable transactions, but only their following equivalent:
+				// support serializable transactions, but only their equivalent SELECT ... LOCK IN SHARE MODE.
+				// We need even stronger locking to avoid deadlocks, so we use SELECT ... FOR UPDATE.
+				// See also: https://dev.mysql.com/doc/refman/5.7/en/innodb-locking-reads.html
 				isoLvl = sql.LevelRepeatableRead
-				selectLock = " LOCK IN SHARE MODE"
+				selectLock = " FOR UPDATE"
 			}
 
 			tx, errBegin := h.db.BeginTxx(ctx, &sql.TxOptions{Isolation: isoLvl})


### PR DESCRIPTION
In its transaction, this method always performs a SELECT ... \<lock clause> and at least one upsert in the same table. If two instances aquire shared locks, those will deadlock each other during the following upsert.

# Tests (edited)

* Source: https://github.com/Icinga/icingadb/pull/788#issuecomment-2388190057

> * With `LOCK IN SHARE MODE` the `SELECT` results in the row of the other instance and the `INSERT` results in a deadlock.
> * With `FOR UPDATE` the `SELECT` is blocked! Therefore, we would not perform an `INSERT` if the other instance is considered active.
> 
> In my opinion, `FOR UPDATE` should be used as it locks stricter and prevents the deadlocks of the `INSERT`s.

> Also, I just started 10 Icinga DB instances each for `LOCK IN SHARE MODE` and `FOR UPDATE` and got no deadlocks with `FOR UPDATE`, but all the time with `LOCK IN SHARE MODE`.

For completeness, the "INSERT" in question contains "ON DUPLICATE KEY UPDATE" which makes it the "upsert" I mentioned.

Anyway, I'd like to properly use locking as recommended per https://dev.mysql.com/doc/refman/5.7/en/innodb-locking-reads.html