### PR TITLE
Make structifyStream() channel types more explicit, e.g. input only

### DIFF
--- a/pkg/icingadb/runtime_updates.go
+++ b/pkg/icingadb/runtime_updates.go
@@ -301,17 +301,24 @@ func (r *RuntimeUpdates) xRead(ctx context.Context, updateMessagesByKey map[stri
 // those messages into Icinga DB entities (contracts.Entity) using the provided structifier.
 // Converted entities are inserted into the upsertEntities or deleteIds channel depending on the "runtime_type" message field.
 func structifyStream(
-	ctx context.Context, updateMessages <-chan redis.XMessage, upsertEntities, upserted chan database.Entity,
-	deleteIds, deleted chan interface{}, structifier structify.MapStructifier,
+	ctx context.Context,
+	updateMessages <-chan redis.XMessage,
+	upsertEntities chan<- database.Entity,
+	upserted <-chan database.Entity,
+	deleteIds chan<- any,
+	deleted <-chan any,
+	structifier structify.MapStructifier,
 ) func() error {
 	if upserted == nil {
-		upserted = make(chan database.Entity)
-		close(upserted)
+		ch := make(chan database.Entity)
+		close(ch)
+		upserted = ch
 	}
 
 	if deleted == nil {
-		deleted = make(chan interface{})
-		close(deleted)
+		ch := make(chan any)
+		close(ch)
+		deleted = ch
 	}
 
 	return func() error {


### PR DESCRIPTION
This enforces which side (caller/function) can read and especially    close/write to a particular channel at compile time.    That leaves less room for bugs (which had to be detected by tests otherwise).