### PR TITLE
Update GHA dependencies via dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,8 @@ updates:
   schedule:
     interval: daily
   open-pull-requests-limit: 10
+
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily


### PR DESCRIPTION
Dependabot supports to automatically refresh GitHub actions as well, so we should use it to avoid such errors:
https://github.com/Icinga/icingadb/actions/runs/10903916830/job/30259089610