### PR TITLE
RetentionConfig: restrict days to uint16

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -55,8 +55,8 @@ type Flags struct {
 
 // RetentionConfig defines configuration for history retention.
 type RetentionConfig struct {
-	HistoryDays uint64                   `yaml:"history-days"`
-	SlaDays     uint64                   `yaml:"sla-days"`
+	HistoryDays uint16                   `yaml:"history-days"`
+	SlaDays     uint16                   `yaml:"sla-days"`
 	Interval    time.Duration            `yaml:"interval" default:"1h"`
 	Count       uint64                   `yaml:"count" default:"5000"`
 	Options     history.RetentionOptions `yaml:"options"`

--- a/pkg/icingadb/history/retention.go
+++ b/pkg/icingadb/history/retention.go
@@ -95,7 +95,7 @@ var RetentionStatements = []retentionStatement{{
 }}
 
 // RetentionOptions defines the non-default mapping of history categories with their retention period in days.
-type RetentionOptions map[string]uint64
+type RetentionOptions map[string]uint16
 
 // Validate checks constraints in the supplied retention options and
 // returns an error if they are violated.
@@ -120,8 +120,8 @@ func (o RetentionOptions) Validate() error {
 type Retention struct {
 	db          *database.DB
 	logger      *logging.Logger
-	historyDays uint64
-	slaDays     uint64
+	historyDays uint16
+	slaDays     uint16
 	interval    time.Duration
 	count       uint64
 	options     RetentionOptions
@@ -129,7 +129,7 @@ type Retention struct {
 
 // NewRetention returns a new Retention.
 func NewRetention(
-	db *database.DB, historyDays uint64, slaDays uint64, interval time.Duration,
+	db *database.DB, historyDays, slaDays uint16, interval time.Duration,
 	count uint64, options RetentionOptions, logger *logging.Logger,
 ) *Retention {
 	return &Retention{
@@ -156,7 +156,7 @@ func (r *Retention) Start(ctx context.Context) error {
 	errs := make(chan error, 1)
 
 	for _, stmt := range RetentionStatements {
-		var days uint64
+		var days uint16
 		switch stmt.RetentionType {
 		case RetentionHistory:
 			if d, ok := r.options[stmt.Category]; ok {
@@ -177,7 +177,7 @@ func (r *Retention) Start(ctx context.Context) error {
 			fmt.Sprintf("Starting history retention for category %s", stmt.Category),
 			zap.Uint64("count", r.count),
 			zap.Duration("interval", r.interval),
-			zap.Uint64("retention-days", days),
+			zap.Uint16("retention-days", days),
 		)
 
 		stmt := stmt


### PR DESCRIPTION
As discussed in #821, allowing huge retention values - as the type uint64 allows - may result in overflows. Especially Go's time.AddDate() method silently overflows for huge values, resulting in unexpected comparison times.

> $ ./icingadb --config <(echo 'retention: {history-days: -1}')
> can't parse YAML file /proc/self/fd/11: cannot unmarshal -1 into Go value of type uint16 ( overflow )
>
> $ ./icingadb --config <(echo 'retention: {history-days: 100000}')
> can't parse YAML file /proc/self/fd/11: cannot unmarshal 100000 into Go value of type uint16 ( overflow )