### PR TITLE
HA State: ensure not this and another instance can be responsible

### DIFF
--- a/pkg/icingadb/ha.go
+++ b/pkg/icingadb/ha.go
@@ -431,6 +431,11 @@ func (h *HA) realize(
 
 		h.signalTakeover(takeover)
 	} else if otherResponsible {
+		if state := h.state.Load(); state.responsible {
+			h.logger.Error("Other instance is responsible while this node itself is responsible, dropping responsibility")
+			h.signalHandover("other instance is responsible as well")
+			// h.signalHandover will update h.state
+		}
 		if state := h.state.Load(); !state.otherResponsible {
 			// Dereference pointer to create a copy of the value it points to.
 			// Ensures that any modifications do not directly affect the original data unless explicitly stored back.


### PR DESCRIPTION
In theory, this should not happen. This assumption is based on the trust in the database transaction performing the HA realization logic. However, one debugged log let one assume that this happened anyway.

This change mostly signals an error while also explicitly giving up the HA state. Doing so should at least alarm a person reading the logs.

---

ref/IP/55850