### PR TITLE
HA: Limit max open database connections to `1`

### DIFF
--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -114,6 +114,7 @@ func run() int {
 			logger.Fatalf("%+v", errors.Wrap(err, "can't create database connection pool from config"))
 		}
 		defer func() { _ = db.Close() }()
+		db.SetMaxOpenConns(1)
 		ha = icingadb.NewHA(ctx, db, heartbeat, logs.GetChildLogger("high-availability"))
 
 		telemetryLogger := logs.GetChildLogger("telemetry")


### PR DESCRIPTION
Previously, the HA feature was allowed to open `max_connections` database connection in parallel to other Icinga DB components. Meaning, Icinga DB wasn't limited to the configured `max_connections`, but effectively to `2 * max_connections`.