### PR TITLE
Replace `int64` with `atomic.Int64` where applicable

### DIFF
--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -204,7 +204,7 @@ func run() int {
 						})
 
 						syncStart := time.Now()
-						atomic.StoreInt64(&telemetry.OngoingSyncStartMilli, syncStart.UnixMilli())
+						telemetry.OngoingSyncStartMilli.Store(syncStart.UnixMilli())
 
 						logger.Info("Starting config sync")
 						for _, factory := range v1.ConfigFactories {
@@ -244,7 +244,7 @@ func run() int {
 
 						g.Go(func() error {
 							configInitSync.Wait()
-							atomic.StoreInt64(&telemetry.OngoingSyncStartMilli, 0)
+							telemetry.OngoingSyncStartMilli.Store(0)
 
 							syncEnd := time.Now()
 							elapsed := syncEnd.Sub(syncStart)

--- a/pkg/icingaredis/telemetry/heartbeat.go
+++ b/pkg/icingaredis/telemetry/heartbeat.go
@@ -77,7 +77,7 @@ func GetCurrentDbConnErr() (string, int64) {
 }
 
 // OngoingSyncStartMilli is to be updated by the main() function.
-var OngoingSyncStartMilli int64
+var OngoingSyncStartMilli atomic.Int64
 
 var boolToStr = map[bool]string{false: "0", true: "1"}
 var startTime = time.Now().UnixMilli()
@@ -100,7 +100,7 @@ func StartHeartbeat(
 	periodic.Start(ctx, interval, func(tick periodic.Tick) {
 		heartbeat := heartbeat.LastReceived()
 		responsibleTsMilli, responsible, otherResponsible := ha.State()
-		ongoingSyncStart := atomic.LoadInt64(&OngoingSyncStartMilli)
+		ongoingSyncStart := OngoingSyncStartMilli.Load()
 		lastSync := syncStats.Load()
 		dbConnErr, dbConnErrSinceMilli := GetCurrentDbConnErr()
 		now := time.Now()


### PR DESCRIPTION
Instead of declaring a field as `int64` and using helper functions for atomic operations, it is better and recommended to use the new atomic types like `atomic.Int64`.