### PR TITLE
schema: Fix broken upgrade script `1.3.0`

### DIFF
--- a/schema/mysql/upgrades/1.3.0.sql
+++ b/schema/mysql/upgrades/1.3.0.sql
@@ -8,11 +8,11 @@ ALTER TABLE notification MODIFY COLUMN properties_checksum binary(20) NOT NULL C
 ALTER TABLE timeperiod_range MODIFY COLUMN range_value text NOT NULL;
 
 ALTER TABLE checkcommand_argument MODIFY COLUMN argument_key varchar(255) NOT NULL;
-ALTER TABLE checkcommand_argument MODIFY COLUMN argument_key_override varchar(255) NOT NULL;
+ALTER TABLE checkcommand_argument MODIFY COLUMN argument_key_override varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL;
 ALTER TABLE eventcommand_argument MODIFY COLUMN argument_key varchar(255) NOT NULL;
-ALTER TABLE eventcommand_argument MODIFY COLUMN argument_key_override varchar(255) NOT NULL;
+ALTER TABLE eventcommand_argument MODIFY COLUMN argument_key_override varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL;
 ALTER TABLE notificationcommand_argument MODIFY COLUMN argument_key varchar(255) NOT NULL;
-ALTER TABLE notificationcommand_argument MODIFY COLUMN argument_key_override varchar(255) NOT NULL;
+ALTER TABLE notificationcommand_argument MODIFY COLUMN argument_key_override varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL;
 
 ALTER TABLE checkcommand_envvar MODIFY COLUMN envvar_key varchar(255) NOT NULL;
 ALTER TABLE eventcommand_envvar MODIFY COLUMN envvar_key varchar(255) NOT NULL;


### PR DESCRIPTION
PR #792 mistakenly added a `NOT NULL` clause to a nullable columns. This PR corrects that by dropping that clause and adding a `DEFAULT NULL` clause, making it consistent the actual schema file.

fixes #855