### PR TITLE
Docs: Redis ACL Username and Database

### DIFF
--- a/config.example.yml
+++ b/config.example.yml
@@ -69,8 +69,14 @@ redis:
   # Defaults to '6380' as the Redis® open source server provided by the 'icingadb-redis' package listens on that port.
 #  port: 6380
 
-  # Authentication password.
+  # Authentication username, requires a `password` being set as well.
+#  username:
+
+  # Authentication password. May be used alone or together with a `username`.
 #  password:
+
+  # Numerical database identifier, defaults to `0`.
+#  database: 0
 
 # Icinga DB logs its activities at various severity levels and any errors that occur either
 # on the console or in systemd's journal. The latter is used automatically when running under systemd.

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -15,7 +15,9 @@ therefore a dedicated Icinga DB instance that connects to it.
 |----------|-------------------------------------------------------------------------------------------------------------------------|
 | host     | **Required.** Host name or address, or absolute Unix socket path.                                                       |
 | port     | **Optional.** TCP port. Defaults to `6380` matching the Redis® open source server port in the `icingadb-redis` package. |
-| password | **Optional.** Authentication password.                                                                                  |
+| username | **Optional.** Authentication username, requires a `password` being set as well.                                         |
+| password | **Optional.** Authentication password. May be used alone or together with a `username`.                                 |
+| database | **Optional.** Numerical database identifier, defaults to `0`.                                                           |
 | tls      | **Optional.** Whether to use TLS.                                                                                       |
 | cert     | **Optional.** Path to TLS client certificate.                                                                           |
 | key      | **Optional.** Path to TLS private key.                                                                                  |


### PR DESCRIPTION
As icinga-go-library v0.4.0 supports these now, it should be documented in Icinga DB.

Closes #782.

---

Requires the icinga-go-library version 0.4.0 release first, #877.