### PR TITLE
test: Rebind Log Output Query for PostgreSQL

### DIFF
--- a/tests/history_test.go
+++ b/tests/history_test.go
@@ -435,12 +435,12 @@ func testHistory(t *testing.T, numNodes int) {
 
 			assert.Equal(t, expected, got, "downtime history should match expected result")
 		}, 5*time.Second, 200*time.Millisecond) {
-			t.Logf("\n%s", utils.MustT(t).String(utils.PrettySelect(db,
+			t.Logf("\n%s", utils.MustT(t).String(utils.PrettySelect(db, db.Rebind(
 				"SELECT h.event_time, h.event_type FROM history h"+
 					" JOIN host ON host.id = h.host_id"+
 					" LEFT JOIN downtime_history d ON d.downtime_id = h.downtime_history_id"+
 					" WHERE host.name = ?"+
-					" ORDER BY h.event_time", hostname)))
+					" ORDER BY h.event_time"), hostname)))
 		}
 
 		testConsistency(t, stream)


### PR DESCRIPTION
While debugging a totally unrelated issue, I stumbled over the following PostgreSQL output:

```
[97] ERROR:  syntax error at or near "ORDER" at character 173
[97] STATEMENT:  SELECT h.event_time, h.event_type FROM history h
                 JOIN host ON host.id = h.host_id
                 LEFT JOIN downtime_history d ON d.downtime_id = h.downtime_history_id
                 WHERE host.name = ?
                 ORDER BY h.event_time
```

The relevant code misses a db.Rebind as the "?" character is for MySQL.