### PR TITLE
HA: Use Transaction for each query

### DIFF
--- a/pkg/icingadb/ha.go
+++ b/pkg/icingadb/ha.go
@@ -392,7 +392,7 @@ func (h *HA) realize(
 				// Insert the environment after each heartbeat takeover if it does not already exist in the database
 				// as the environment may have changed, although this is likely to happen very rarely.
 				stmt, _ = h.db.BuildInsertIgnoreStmt(h.environment)
-				if _, err := h.db.NamedExecContext(ctx, stmt, h.environment); err != nil {
+				if _, err := tx.NamedExecContext(ctx, stmt, h.environment); err != nil {
 					return database.CantPerformQuery(err, stmt)
 				}
 			}


### PR DESCRIPTION
During #800, the commit dd0ca8fb072ae8713b7e3f32df5b6417aa0fb7b6 inlined the HA.insertEnvironment method into the retryable realization function. However, while doing so, I forgot to change the query execution context from h.db to tx. This resulted in an error when being used together with a single database connection, as introduced in #828.

---

Thanks for @yhabteab for the pair debug session :)