### PR TITLE
Retention: switch number of days type uint16 -> float64

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -89,8 +89,8 @@ func (f Flags) IsExplicitConfigPath() bool {
 
 // RetentionConfig defines configuration for history retention.
 type RetentionConfig struct {
-	HistoryDays uint16                   `yaml:"history-days" env:"HISTORY_DAYS"`
-	SlaDays     uint16                   `yaml:"sla-days" env:"SLA_DAYS"`
+	HistoryDays float64                  `yaml:"history-days" env:"HISTORY_DAYS"`
+	SlaDays     float64                  `yaml:"sla-days" env:"SLA_DAYS"`
 	Interval    time.Duration            `yaml:"interval" env:"INTERVAL" default:"1h"`
 	Count       uint64                   `yaml:"count" env:"COUNT" default:"5000"`
 	Options     history.RetentionOptions `yaml:"options" env:"OPTIONS"`


### PR DESCRIPTION
This allows specifying less than a day as threshold. That is especially useful if history doesn't mattter as much as disk space.

I want my large (ref/NC/820479) test setup to run over WE w/o running out of disk space. So I built this.