### PR TITLE
icingadb-migrate: Explicit AS in SELECT

### DIFF
--- a/cmd/icingadb-migrate/embed/comment_query.sql
+++ b/cmd/icingadb-migrate/embed/comment_query.sql
@@ -1,10 +1,16 @@
-SELECT ch.commenthistory_id, UNIX_TIMESTAMP(ch.entry_time) entry_time,
-  ch.entry_time_usec, ch.entry_type, ch.author_name, ch.comment_data, ch.is_persistent,
-  COALESCE(UNIX_TIMESTAMP(ch.expiration_time), 0) expiration_time,
-  COALESCE(UNIX_TIMESTAMP(ch.deletion_time), 0) deletion_time,
+SELECT
+  ch.commenthistory_id,
+  UNIX_TIMESTAMP(ch.entry_time) AS entry_time,
+  ch.entry_time_usec,
+  ch.entry_type,
+  ch.author_name,
+  ch.comment_data,
+  ch.is_persistent,
+  COALESCE(UNIX_TIMESTAMP(ch.expiration_time), 0) AS expiration_time,
+  COALESCE(UNIX_TIMESTAMP(ch.deletion_time), 0) AS deletion_time,
   ch.deletion_time_usec,
-  COALESCE(ch.name, CONCAT(o.name1, '!', COALESCE(o.name2, ''), '!', ch.commenthistory_id, '-', ch.object_id)) name,
-  o.objecttype_id, o.name1, COALESCE(o.name2, '') name2
+  COALESCE(ch.name, CONCAT(o.name1, '!', COALESCE(o.name2, ''), '!', ch.commenthistory_id, '-', ch.object_id)) AS name,
+  o.objecttype_id, o.name1, COALESCE(o.name2, '') AS name2
 FROM icinga_commenthistory ch USE INDEX (PRIMARY)
 INNER JOIN icinga_objects o ON o.object_id=ch.object_id
 WHERE ch.commenthistory_id BETWEEN :fromid AND :toid

--- a/cmd/icingadb-migrate/embed/downtime_query.sql
+++ b/cmd/icingadb-migrate/embed/downtime_query.sql
@@ -1,11 +1,24 @@
-SELECT dh.downtimehistory_id, UNIX_TIMESTAMP(dh.entry_time) entry_time, dh.author_name, dh.comment_data,
-  dh.is_fixed, dh.duration, UNIX_TIMESTAMP(dh.scheduled_start_time) scheduled_start_time,
-  COALESCE(UNIX_TIMESTAMP(dh.scheduled_end_time), 0) scheduled_end_time, dh.was_started,
-  COALESCE(UNIX_TIMESTAMP(dh.actual_start_time), 0) actual_start_time, dh.actual_start_time_usec,
-  COALESCE(UNIX_TIMESTAMP(dh.actual_end_time), 0) actual_end_time, dh.actual_end_time_usec, dh.was_cancelled,
-  COALESCE(UNIX_TIMESTAMP(dh.trigger_time), 0) trigger_time,
-  COALESCE(dh.name, CONCAT(o.name1, '!', COALESCE(o.name2, ''), '!', dh.downtimehistory_id, '-', dh.object_id)) name,
-  o.objecttype_id, o.name1, COALESCE(o.name2, '') name2, COALESCE(sd.name, '') triggered_by
+SELECT
+  dh.downtimehistory_id,
+  UNIX_TIMESTAMP(dh.entry_time) AS entry_time,
+  dh.author_name,
+  dh.comment_data,
+  dh.is_fixed,
+  dh.duration,
+  UNIX_TIMESTAMP(dh.scheduled_start_time) AS scheduled_start_time,
+  COALESCE(UNIX_TIMESTAMP(dh.scheduled_end_time), 0) AS scheduled_end_time,
+  dh.was_started,
+  COALESCE(UNIX_TIMESTAMP(dh.actual_start_time), 0) AS actual_start_time,
+  dh.actual_start_time_usec,
+  COALESCE(UNIX_TIMESTAMP(dh.actual_end_time), 0) AS actual_end_time,
+  dh.actual_end_time_usec,
+  dh.was_cancelled,
+  COALESCE(UNIX_TIMESTAMP(dh.trigger_time), 0) AS trigger_time,
+  COALESCE(dh.name, CONCAT(o.name1, '!', COALESCE(o.name2, ''), '!', dh.downtimehistory_id, '-', dh.object_id)) AS name,
+  o.objecttype_id,
+  o.name1,
+  COALESCE(o.name2, '') AS name2,
+  COALESCE(sd.name, '') AS triggered_by
 FROM icinga_downtimehistory dh USE INDEX (PRIMARY)
 INNER JOIN icinga_objects o ON o.object_id=dh.object_id
 LEFT JOIN icinga_scheduleddowntime sd ON sd.scheduleddowntime_id=dh.triggered_by_id

--- a/cmd/icingadb-migrate/embed/flapping_query.sql
+++ b/cmd/icingadb-migrate/embed/flapping_query.sql
@@ -1,6 +1,14 @@
-SELECT fh.flappinghistory_id, UNIX_TIMESTAMP(fh.event_time) event_time,
-  fh.event_time_usec, fh.event_type, fh.percent_state_change, fh.low_threshold,
-  fh.high_threshold, o.objecttype_id, o.name1, COALESCE(o.name2, '') name2
+SELECT
+  fh.flappinghistory_id,
+  UNIX_TIMESTAMP(fh.event_time) AS event_time,
+  fh.event_time_usec,
+  fh.event_type,
+  fh.percent_state_change,
+  fh.low_threshold,
+  fh.high_threshold,
+  o.objecttype_id,
+  o.name1,
+  COALESCE(o.name2, '') AS name2
 FROM icinga_flappinghistory fh USE INDEX (PRIMARY)
 INNER JOIN icinga_objects o ON o.object_id=fh.object_id
 WHERE fh.flappinghistory_id BETWEEN :fromid AND :toid

--- a/cmd/icingadb-migrate/embed/notification_query.sql
+++ b/cmd/icingadb-migrate/embed/notification_query.sql
@@ -1,6 +1,15 @@
-SELECT n.notification_id, n.notification_reason, UNIX_TIMESTAMP(n.end_time) end_time,
-  n.end_time_usec, n.state, COALESCE(n.output, '') output, n.long_output,
-  n.contacts_notified, o.objecttype_id, o.name1, COALESCE(o.name2, '') name2
+SELECT
+  n.notification_id,
+  n.notification_reason,
+  UNIX_TIMESTAMP(n.end_time) AS end_time,
+  n.end_time_usec,
+  n.state,
+  COALESCE(n.output, '') AS output,
+  n.long_output,
+  n.contacts_notified,
+  o.objecttype_id,
+  o.name1,
+  COALESCE(o.name2, '') AS name2
 FROM icinga_notifications n USE INDEX (PRIMARY)
 INNER JOIN icinga_objects o ON o.object_id=n.object_id
 WHERE n.notification_id BETWEEN :fromid AND :toid

--- a/cmd/icingadb-migrate/embed/state_query.sql
+++ b/cmd/icingadb-migrate/embed/state_query.sql
@@ -1,6 +1,19 @@
-SELECT sh.statehistory_id, UNIX_TIMESTAMP(sh.state_time) state_time, sh.state_time_usec, sh.state,
-  sh.state_type, sh.current_check_attempt, sh.max_check_attempts, sh.last_state, sh.last_hard_state,
-  sh.output, sh.long_output, sh.check_source, o.objecttype_id, o.name1, COALESCE(o.name2, '') name2
+SELECT
+  sh.statehistory_id,
+  UNIX_TIMESTAMP(sh.state_time) AS state_time,
+  sh.state_time_usec,
+  sh.state,
+  sh.state_type,
+  sh.current_check_attempt,
+  sh.max_check_attempts,
+  sh.last_state,
+  sh.last_hard_state,
+  sh.output,
+  sh.long_output,
+  sh.check_source,
+  o.objecttype_id,
+  o.name1,
+  COALESCE(o.name2, '') AS name2
 FROM icinga_statehistory sh USE INDEX (PRIMARY)
 INNER JOIN icinga_objects o ON o.object_id=sh.object_id
 WHERE sh.statehistory_id BETWEEN :fromid AND :toid


### PR DESCRIPTION
By introducing an explicit "AS" to set output names in the SELECT column list, there are no issues with reserved names. Unfortunately, this happened on PostgreSQL in the older version 13 with the reserved name "name". Adding "AS" mitigates this issue.

Furthermore, I have put each column name in its own line for the SELECT queries to ease the readability of the query itself and of future diffs.

Fixes #884.