### PR TITLE
Auto Import Database Schema

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -58,6 +58,14 @@ type Flags struct {
 	// Config is the path to the config file. If not provided, it defaults to DefaultConfigPath.
 	Config string `short:"c" long:"config" description:"path to config file (default: /etc/icingadb/config.yml)"`
 	// default must be kept in sync with DefaultConfigPath.
+
+	// DatabaseAutoImport results in an initial schema check and update; mostly for containerized setups.
+	DatabaseAutoImport bool `long:"database-auto-import" description:"import database schema on startup if database is empty"`
+
+	// DatabaseSchemaDir is the root directory for schema files to be used when DatabaseAutoImport is requested.
+	//
+	// The directory structure must mimic the git repo's schema dir, containing ./mysql/schema.sql and ./pgsql/schema.sql.
+	DatabaseSchemaDir string `long:"database-schema-dir" description:"directory for --database-auto-import, expects ./{my,pg}sql/schema.sql files" default:"./schema/"`
 }
 
 // GetConfigPath retrieves the path to the configuration file.

--- a/pkg/icingadb/schema.go
+++ b/pkg/icingadb/schema.go
@@ -2,11 +2,15 @@ package icingadb
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"github.com/icinga/icinga-go-library/backoff"
 	"github.com/icinga/icinga-go-library/database"
 	"github.com/icinga/icinga-go-library/retry"
+	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
+	"os"
+	"path"
 	"time"
 )
 
@@ -15,7 +19,19 @@ const (
 	expectedPostgresSchemaVersion = 4
 )
 
-// CheckSchema asserts the database schema of the expected version being present.
+// ErrSchemaNotExists implies that no Icinga DB schema has been imported.
+var ErrSchemaNotExists = stderrors.New("no database schema exists")
+
+// ErrSchemaMismatch implies an unexpected schema version, most likely after Icinga DB was updated but the database
+// missed the schema upgrade.
+var ErrSchemaMismatch = stderrors.New("unexpected database schema version")
+
+// CheckSchema verifies the correct database schema is present.
+//
+// This function returns the following error types, possibly wrapped:
+//   - If no schema exists, the error returned is ErrSchemaNotExists.
+//   - If the schema version does not match the expected version, the error returned is ErrSchemaMismatch.
+//   - Otherwise, the original error is returned, for example in case of general database problems.
 func CheckSchema(ctx context.Context, db *database.DB) error {
 	var expectedDbSchemaVersion uint16
 	switch db.DriverName() {
@@ -23,19 +39,25 @@ func CheckSchema(ctx context.Context, db *database.DB) error {
 		expectedDbSchemaVersion = expectedMysqlSchemaVersion
 	case database.PostgreSQL:
 		expectedDbSchemaVersion = expectedPostgresSchemaVersion
+	default:
+		return errors.Errorf("unsupported database driver %q", db.DriverName())
+	}
+
+	if hasSchemaTable, err := db.HasTable(ctx, "icingadb_schema"); err != nil {
+		return errors.Wrap(err, "can't verify existence of database schema table")
+	} else if !hasSchemaTable {
+		return ErrSchemaNotExists
 	}
 
 	var version uint16
-
 	err := retry.WithBackoff(
 		ctx,
-		func(ctx context.Context) (err error) {
+		func(ctx context.Context) error {
 			query := "SELECT version FROM icingadb_schema ORDER BY id DESC LIMIT 1"
-			err = db.QueryRowxContext(ctx, query).Scan(&version)
-			if err != nil {
-				err = database.CantPerformQuery(err, query)
+			if err := db.QueryRowxContext(ctx, query).Scan(&version); err != nil {
+				return database.CantPerformQuery(err, query)
 			}
-			return
+			return nil
 		},
 		retry.Retryable,
 		backoff.NewExponentialWithJitter(128*time.Millisecond, 1*time.Minute),
@@ -48,11 +70,50 @@ func CheckSchema(ctx context.Context, db *database.DB) error {
 		// Since these error messages are trivial and mostly caused by users, we don't need
 		// to print a stack trace here. However, since errors.Errorf() does this automatically,
 		// we need to use fmt instead.
-		return fmt.Errorf(
-			"unexpected database schema version: v%d (expected v%d), please make sure you have applied all database"+
-				" migrations after upgrading Icinga DB", version, expectedDbSchemaVersion,
+		return fmt.Errorf("%w: v%d (expected v%d), please make sure you have applied all database"+
+			" migrations after upgrading Icinga DB", ErrSchemaMismatch, version, expectedDbSchemaVersion,
 		)
 	}
 
 	return nil
+}
+
+// ImportSchema performs an initial schema import in the db.
+//
+// This function assumes that no schema exists. So it should only be called after a prior CheckSchema call.
+func ImportSchema(
+	ctx context.Context,
+	db *database.DB,
+	databaseSchemaDir string,
+) error {
+	var schemaFileDirPart string
+	switch db.DriverName() {
+	case database.MySQL:
+		schemaFileDirPart = "mysql"
+	case database.PostgreSQL:
+		schemaFileDirPart = "pgsql"
+	default:
+		return errors.Errorf("unsupported database driver %q", db.DriverName())
+	}
+
+	schemaFile := path.Join(databaseSchemaDir, schemaFileDirPart, "schema.sql")
+	schema, err := os.ReadFile(schemaFile) // #nosec G304 -- path is constructed from "trusted" command line user input
+	if err != nil {
+		return errors.Wrapf(err, "can't open schema file %q", schemaFile)
+	}
+
+	queries := []string{string(schema)}
+	if db.DriverName() == database.MySQL {
+		// MySQL/MariaDB requires the schema to be imported on a statement by statement basis.
+		queries = database.MysqlSplitStatements(string(schema))
+	}
+
+	return errors.Wrapf(db.ExecTx(ctx, func(ctx context.Context, tx *sqlx.Tx) error {
+		for _, query := range queries {
+			if _, err := tx.ExecContext(ctx, query); err != nil {
+				return errors.Wrap(database.CantPerformQuery(err, query), "can't perform schema import")
+			}
+		}
+		return nil
+	}), "can't import database schema from %q", schemaFile)
 }


### PR DESCRIPTION
To get rid of docker-icingadb and its additional entry point, the schema import functionality has been implemented directly in Icinga DB. Using the new `--database-auto-import` command line argument will result in an automatic schema import if no schema is found.

The implementation is split between the already existing `CheckSchema` function and the introduced `ImportSchema` function.

The `CheckSchema` function is now able to distinguish between the absence of a schema and an incorrect schema version. Both situations return a separate error type.

As before, `CheckSchema` is called in the `main` function. If the error type now implies the absence of a schema (`ErrSchemaNotExists`) and the `--database-auto-import` flag is set, the auto-import is started.

The schema import itself is performed in the new `ImportSchema` function, which loads the schema from a given file and inserts it within a transaction, allowing to rollback in case of an error.

<details><summary>MySQL Run</summary>
<p>

```
$ docker run --name mariadb-icingadb -e MARIADB_ROOT_PASSWORD=supersicher -p 3306:3306 -d mariadb:latest

$ docker exec -it mariadb-icingadb mariadb --password=supersicher
MariaDB [(none)]> create database icingadb;
Query OK, 1 row affected (0.001 sec)
MariaDB [(none)]> ^D

$ # Start w/o a schema
$ ./icingadb --config config.yml
2025-03-27T09:40:43.379+0100    INFO    icingadb        Starting Icinga DB daemon (1.2.1-g3768602-dirty)
2025-03-27T09:40:43.379+0100    INFO    icingadb        Connecting to database at 'mysql://root@localhost:3306/icingadb'
2025-03-27T09:40:43.383+0100    FATAL   icingadb        The database schema is missing


$ # Start w/o a schema, but allow imports
$ ./icingadb --config config.yml --database-auto-import
2025-03-27T09:40:46.378+0100    INFO    icingadb        Starting Icinga DB daemon (1.2.1-g3768602-dirty)
2025-03-27T09:40:46.378+0100    INFO    icingadb        Connecting to database at 'mysql://root@localhost:3306/icingadb'
2025-03-27T09:40:46.383+0100    INFO    icingadb        Starting database schema auto import
2025-03-27T09:40:46.711+0100    INFO    icingadb        The database schema was successfully imported
[ . . . ]

$ # Simulate an outdated schema version
$ docker exec -it mariadb-icingadb mariadb --password=supersicher icingadb
MariaDB [icingadb]> update icingadb_schema set version = 1;
Query OK, 1 row affected (0.008 sec)
Rows matched: 1  Changed: 1  Warnings: 0
MariaDB [icingadb]> ^D
$ ./icingadb --config config.yml
2025-03-27T09:41:37.313+0100    INFO    icingadb        Starting Icinga DB daemon (1.2.1-g3768602-dirty)
2025-03-27T09:41:37.313+0100    INFO    icingadb        Connecting to database at 'mysql://root@localhost:3306/icingadb'
2025-03-27T09:41:37.317+0100    FATAL   icingadb        unexpected database schema version: v1 (expected v6), please make sure you have applied all database migrations after upgrading Icinga DB

$ # Reset schema version
$ docker exec -it mariadb-icingadb mariadb --password=supersicher icingadb
MariaDB [icingadb]> update icingadb_schema set version = 6;
Query OK, 1 row affected (0.008 sec)
Rows matched: 1  Changed: 1  Warnings: 0
MariaDB [icingadb]> ^D

$ # Start w/ correct schema
./icingadb --config config.yml
2025-03-27T09:42:00.220+0100    INFO    icingadb        Starting Icinga DB daemon (1.2.1-g3768602-dirty)
2025-03-27T09:42:00.220+0100    INFO    icingadb        Connecting to database at 'mysql://root@localhost:3306/icingadb'
[ . . . ]

$ # Retry without a database
$ docker stop mariadb-icingadb
$ docker container rm mariadb-icingadb
$ ./icingadb --config config.yml
2025-03-27T09:42:24.372+0100    INFO    icingadb        Starting Icinga DB daemon (1.2.1-g3768602-dirty)
2025-03-27T09:42:24.372+0100    INFO    icingadb        Connecting to database at 'mysql://root@localhost:3306/icingadb'
2025-03-27T09:42:24.373+0100    WARN    database        Can't connect to database. Retrying     {"error": "dial tcp [::1]:3306: connect: connection refused"}
[ . . . ]
```

</p>
</details>

<details><summary>PostgreSQL Run</summary>
<p>

```
$ docker run --name postgres-icingadb -e POSTGRES_PASSWORD=supersicher -p 5432:5432 -d postgres:latest

$ docker exec -it postgres-icingadb psql -U postgres
postgres=# create database icingadb;
CREATE DATABASE
postgres=# ^D

$ # Start w/o a schema
$ ./icingadb --config config.yml
2025-03-27T09:43:12.578+0100    INFO    icingadb        Starting Icinga DB daemon (1.2.1-g3768602-dirty)
2025-03-27T09:43:12.578+0100    INFO    icingadb        Connecting to database at 'pgsql://postgres@localhost:5432/icingadb'
2025-03-27T09:43:12.594+0100    FATAL   icingadb        The database schema is missing

$ # Start w/o a schema, but allow imports
$ ./icingadb --config config.yml --database-auto-import
2025-03-27T09:43:24.688+0100    INFO    icingadb        Starting Icinga DB daemon (1.2.1-g3768602-dirty)
2025-03-27T09:43:24.688+0100    INFO    icingadb        Connecting to database at 'pgsql://postgres@localhost:5432/icingadb'
2025-03-27T09:43:24.703+0100    INFO    icingadb        Starting database schema auto import
2025-03-27T09:43:24.765+0100    INFO    icingadb        The database schema was successfully imported
[ . . . ]

$ # Simulate an outdated schema version
$ docker exec -it postgres-icingadb psql -U postgres icingadb
icingadb=# update icingadb_schema set version = 1;
UPDATE 1
icingadb=# ^D
$ ./icingadb --config config.yml
2025-03-27T09:43:53.056+0100    INFO    icingadb        Starting Icinga DB daemon (1.2.1-g3768602-dirty)
2025-03-27T09:43:53.056+0100    INFO    icingadb        Connecting to database at 'pgsql://postgres@localhost:5432/icingadb'
2025-03-27T09:43:53.065+0100    FATAL   icingadb        unexpected database schema version: v1 (expected v4), please make sure you have applied all database migrations after upgrading Icinga DB

$ # Reset schema version
$ docker exec -it postgres-icingadb psql -U postgres icingadb
icingadb=# update icingadb_schema set version = 4;
UPDATE 1
icingadb=# ^D

$ # Start w/ correct schema
./icingadb --config config.yml
2025-03-27T09:44:09.194+0100    INFO    icingadb        Starting Icinga DB daemon (1.2.1-g3768602-dirty)
2025-03-27T09:44:09.194+0100    INFO    icingadb        Connecting to database at 'pgsql://postgres@localhost:5432/icingadb'
[ . . . ]

$ # Retry without a database
$ docker stop postgres-icingadb
$ docker container rm postgres-icingadb
$ ./icingadb --config config.yml
2025-03-27T09:44:34.330+0100    INFO    icingadb        Starting Icinga DB daemon (1.2.1-g3768602-dirty)
2025-03-27T09:44:34.330+0100    INFO    icingadb        Connecting to database at 'pgsql://postgres@localhost:5432/icingadb'
2025-03-27T09:44:34.331+0100    WARN    database        Can't connect to database. Retrying     {"error": "dial tcp [::1]:5432: connect: connection refused"}
[ . . . ]
```

</p>
</details>

Fixes #896.