### PR TITLE
`container-image` workflow: Don't push attestations to image registries

### DIFF
--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -103,7 +103,7 @@ jobs:
         with:
           subject-name: ghcr.io/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build-and-push.outputs.digest }}
-          push-to-registry: true
+          push-to-registry: false
 
       - name: Generate artifact attestation for Docker Hub
         if: github.event_name != 'pull_request'
@@ -115,4 +115,4 @@ jobs:
           # [^1]: https://github.com/actions/attest-build-provenance?tab=readme-ov-file#container-image
           subject-name: index.docker.io/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build-and-push.outputs.digest }}
-          push-to-registry: true
+          push-to-registry: false


### PR DESCRIPTION
Without further investigation, this only seems to push the image with the digest as a tag, which only pollutes the registry.