### PR TITLE
Containerfile: allow running the binary without absolute path

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -40,4 +40,5 @@ COPY --from=build /icingadb /icingadb
 
 USER icinga
 
-CMD ["/icingadb", "--database-auto-import"]
+ENV PATH=/
+CMD ["icingadb", "--database-auto-import"]


### PR DESCRIPTION
This sets the PATH environment variable so that the binary installed to the container image can be found by just its name. This makes it nicer to manually provide a command by the container, so for example, now "docker run --rm -it icinga/icingadb:dev icingadb --version" works. The binary is still installed under the same path, so it can still be invoked using the same absolute path as before.

### Tests

#### main branch

```
$ docker run --rm -it icinga/icingadb:dev icingadb --version 
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: exec: "icingadb": executable file not found in $PATH

Run 'docker run --help' for more information
$ docker run --rm -it icinga/icingadb:dev /icingadb --version
Icinga DB version: 1.2.1-g5d43cb2

Build information:
  Go version: go1.24.2 (linux, amd64)
  Git commit: 5d43cb20d937f1d88d838090b10831ca47b131ea
```

#### This PR

```
$ docker run --rm -it icinga/icingadb:dev icingadb --version
Icinga DB version: 1.2.1-gd337826

Build information:
  Go version: go1.24.2 (linux, amd64)
  Git commit: d337826415bf13b7de110a30076e779ce8a9e686
$ docker run --rm -it icinga/icingadb:dev /icingadb --version
Icinga DB version: 1.2.1-gd337826

Build information:
  Go version: go1.24.2 (linux, amd64)
  Git commit: d337826415bf13b7de110a30076e779ce8a9e686
```

### Additional information

This is unrelated to the recent rework of the container image, i.e. this never worked before. So it's not strictly necessary to include this in 1.3.0 (but feel free to include it nonetheless).