### PR TITLE
go.mod: Bump go version to 1.24.1

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -34,10 +34,6 @@ jobs:
         with:
           go-version: 1.x
 
-      - uses: dominikh/staticcheck-action@fe1dd0c3658873b46f8c9bb3291096a617310ca6 # v1.3.1
-        with:
-          install-go: false
-
       - uses: golangci/golangci-lint-action@v7
         with:
           version: latest

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/icinga/icingadb
 
-go 1.23.0
+go 1.24.1
 
 require (
 	github.com/creasty/defaults v1.8.0


### PR DESCRIPTION
    go.mod: Bump go version to 1.24.1

    Recently the dependabot PRs would otherwise add the toolchain directive.


    GHA: Remove staticheck action from Go Workflow

    After bumping the Go version to 1.24.1, the staticcheck-action fails
    since it is outdated. No update is available. However, since staticcheck
    is enabled by default in the golangci-lint action, it can be removed.