### PR TITLE
doc/06-Migration.md: ido and icingadb config sections

### DIFF
--- a/doc/06-Migration.md
+++ b/doc/06-Migration.md
@@ -41,6 +41,12 @@ sections of the configuration.
 Both the IDO and Icinga DB support MySQL and PostgreSQL. You can migrate from
 and to both types, including from one type to the other.
 
+The fields of the `ido` and `icingadb` sections follow the Icinga DB
+[database configuration format](03-Configuration.md#database-configuration),
+except for `to` and `from` in `ido`, which are described in the following
+documentation section. The `icingadb` section should be identical to the
+`database` section of the Icinga DB configuration for most users.
+
 #### Input Time Range
 
 The migration tool allows you to restrict the time range of the history events


### PR DESCRIPTION
The fields of both ido and icingadb were not described so far. As being an IGL database.Config, they match Icinga DB's database configuration, which was referenced, with the from/to exception.

References #949.