### PR TITLE
Retention: Unordered deletion in CleanupStmt

### DIFF
--- a/pkg/icingadb/cleanup.go
+++ b/pkg/icingadb/cleanup.go
@@ -80,11 +80,11 @@ func (stmt *CleanupStmt) CleanupOlderThan(
 func (stmt *CleanupStmt) build(driverName string, limit uint64) string {
 	switch driverName {
 	case database.MySQL:
-		return fmt.Sprintf(`DELETE FROM %[1]s WHERE environment_id = :environment_id AND %[2]s < :time
-ORDER BY %[2]s LIMIT %[3]d`, stmt.Table, stmt.Column, limit)
+		return fmt.Sprintf(`DELETE FROM %[1]s WHERE environment_id = :environment_id AND %[2]s < :time LIMIT %[3]d`,
+			stmt.Table, stmt.Column, limit)
 	case database.PostgreSQL:
 		return fmt.Sprintf(`WITH rows AS (
-SELECT %[1]s FROM %[2]s WHERE environment_id = :environment_id AND %[3]s < :time ORDER BY %[3]s LIMIT %[4]d
+SELECT %[1]s FROM %[2]s WHERE environment_id = :environment_id AND %[3]s < :time LIMIT %[4]d
 )
 DELETE FROM %[2]s WHERE %[1]s IN (SELECT %[1]s FROM rows)`, stmt.PK, stmt.Table, stmt.Column, limit)
 	default:

--- a/pkg/icingadb/history/retention.go
+++ b/pkg/icingadb/history/retention.go
@@ -222,7 +222,6 @@ func (r *Retention) Start(ctx context.Context) error {
 			zap.Uint16("retention-days", days),
 		)
 
-		stmt := stmt
 		periodic.Start(ctx, r.interval, func(tick periodic.Tick) {
 			olderThan := tick.Time.AddDate(0, 0, -int(days))
 
@@ -242,9 +241,11 @@ func (r *Retention) Start(ctx context.Context) error {
 				return
 			}
 
+			level := zap.DebugLevel
 			if deleted > 0 {
-				r.logger.Infof("Removed %d old %s history items", deleted, stmt.Category)
+				level = zap.InfoLevel
 			}
+			r.logger.Logf(level, "Removed %d old %s history items", deleted, stmt.Category)
 		}, periodic.Immediate())
 	}
 


### PR DESCRIPTION
Speed up history retention by deleting old rows in an unordered fashion.

History retention deletes all rows in the history table if their timestamp is older than the configured retention period. This deletion is performed in bulk, typically limiting each statement to 5,000 entries. After the final iteration, all older entries are deleted.

So far, the deletion queries required an order for the deletion process to start with the oldest rows. If the tables to be cleaned were huge, ordering the data would be expensive. However, since all old data will be deleted without further delay, deleting the data in order is unnecessary.

For reference, compare the two following execution plans generated by PostgreSQL for a state_history table of round about 32k entries.

```
icingadb=> EXPLAIN SELECT id FROM state_history WHERE environment_id = E'\\xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' AND event_time < 1747300387000 ORDER BY event_time LIMIT 5000;
                                                                         QUERY PLAN
------------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.41..662.54 rows=5000 width=30)
   ->  Index Scan using idx_state_history_env_event_time on state_history  (cost=0.41..4266.61 rows=32216 width=30)
         Index Cond: (((environment_id)::bytea = '\xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'::bytea) AND ((event_time)::bigint < '1747300387000'::bigint))
(3 rows)

icingadb=> EXPLAIN SELECT id FROM state_history WHERE environment_id = E'\\xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' AND event_time < 1747300387000 LIMIT 5000;
                                                                       QUERY PLAN
--------------------------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=0.00..264.82 rows=5000 width=22)
   ->  Seq Scan on state_history  (cost=0.00..1706.28 rows=32216 width=22)
         Filter: (((event_time)::bigint < '1747300387000'::bigint) AND ((environment_id)::bytea = '\xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'::bytea))
(3 rows)
```

The calculated cost decreased significantly from "0.41..662.54" to "0.00..264.82", since unordered deletion do no longer requires an expensive index scan.

By the way, this is not just nitpicking, but addresses an actual problem of expensive retention queries locking tables, as reported in #893.

---

As a related second change:

While the starting of each cleanup run was logged at debug level, only runs actually deleting entries were logged. Thus, from reading the logs it was not clear when the history retention job has finished.

The code was adjusted to continue logging deleting history queries at info level, while non-effective runs are now logged at debug.

Furthermore, the loop variable was removed since it became obsolete with Go 1.22, <https://go.dev/wiki/LoopvarExperiment>.