### PR TITLE
Add icingadb_version column to icingadb_instance

### DIFF
--- a/pkg/icingadb/ha.go
+++ b/pkg/icingadb/ha.go
@@ -12,6 +12,7 @@ import (
 	"github.com/icinga/icinga-go-library/retry"
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-go-library/utils"
+	"github.com/icinga/icingadb/internal"
 	v1 "github.com/icinga/icingadb/pkg/icingadb/v1"
 	"github.com/icinga/icingadb/pkg/icingaredis"
 	icingaredisv1 "github.com/icinga/icingadb/pkg/icingaredis/v1"
@@ -376,6 +377,7 @@ func (h *HA) realize(
 				Icinga2EventHandlersEnabled:       s.EventHandlersEnabled,
 				Icinga2FlapDetectionEnabled:       s.FlapDetectionEnabled,
 				Icinga2PerformanceDataEnabled:     s.PerformanceDataEnabled,
+				IcingadbVersion:                   internal.Version.Version,
 			}
 
 			stmt, _ := h.db.BuildUpsertStmt(i)

--- a/pkg/icingadb/v1/icingadb_instance.go
+++ b/pkg/icingadb/v1/icingadb_instance.go
@@ -18,4 +18,5 @@ type IcingadbInstance struct {
 	Icinga2EventHandlersEnabled       types.Bool      `json:"icinga2_event_handlers_enabled"`
 	Icinga2FlapDetectionEnabled       types.Bool      `json:"icinga2_flap_detection_enabled"`
 	Icinga2PerformanceDataEnabled     types.Bool      `json:"icinga2_performance_data_enabled"`
+	IcingadbVersion                   string          `json:"-"`
 }

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -547,6 +547,8 @@ CREATE TABLE icingadb_instance (
   icinga2_flap_detection_enabled enum('n', 'y') NOT NULL,
   icinga2_performance_data_enabled enum('n', 'y') NOT NULL,
 
+  icingadb_version varchar(255) NOT NULL,
+
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 

--- a/schema/mysql/upgrades/1.4.0.sql
+++ b/schema/mysql/upgrades/1.4.0.sql
@@ -63,5 +63,8 @@ CREATE TABLE dependency_edge (
   UNIQUE INDEX idx_dependency_edge_from_node_to_node_id (from_node_id, to_node_id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
+ALTER TABLE icingadb_instance ADD COLUMN icingadb_version varchar(255) NOT NULL DEFAULT 'unknown' AFTER icinga2_performance_data_enabled;
+ALTER TABLE icingadb_instance MODIFY COLUMN icingadb_version varchar(255) NOT NULL;
+
 INSERT INTO icingadb_schema (version, timestamp)
   VALUES (7, UNIX_TIMESTAMP() * 1000);

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -799,6 +799,8 @@ CREATE TABLE icingadb_instance (
   icinga2_flap_detection_enabled boolenum NOT NULL DEFAULT 'n',
   icinga2_performance_data_enabled boolenum NOT NULL DEFAULT 'n',
 
+  icingadb_version varchar(255) NOT NULL,
+
   CONSTRAINT pk_icingadb_instance PRIMARY KEY (id)
 );
 

--- a/schema/pgsql/upgrades/1.4.0.sql
+++ b/schema/pgsql/upgrades/1.4.0.sql
@@ -108,5 +108,8 @@ COMMENT ON COLUMN dependency_edge.from_node_id IS 'dependency_node.id';
 COMMENT ON COLUMN dependency_edge.to_node_id IS 'dependency_node.id';
 COMMENT ON COLUMN dependency_edge.dependency_edge_state_id IS 'sha1(dependency_edge_state.id)';
 
+ALTER TABLE icingadb_instance ADD COLUMN icingadb_version varchar(255) NOT NULL DEFAULT 'unknown';
+ALTER TABLE icingadb_instance ALTER COLUMN icingadb_version DROP DEFAULT;
+
 INSERT INTO icingadb_schema (version, timestamp)
   VALUES (5, extract(epoch from now()) * 1000);


### PR DESCRIPTION
Store the current Icinga DB version in the icingadb_instance table to be shown in Icinga DB Web's health view.

Fixes #962.

---

@nilmerg: This would be a very straight forward solution, adding a `icingadb_version` column to be populated by Icinga DB. Thus, the Icinga DB version would be stored next to the Icinga 2 version. Does this work for Web?