### PR TITLE
pkg/icingadb: Use backoff.DefaultBackoff

### DIFF
--- a/pkg/icingadb/cleanup.go
+++ b/pkg/icingadb/cleanup.go
@@ -53,7 +53,7 @@ func (stmt *CleanupStmt) CleanupOlderThan(
 				return err
 			},
 			retry.Retryable,
-			backoff.NewExponentialWithJitter(1*time.Millisecond, 1*time.Second),
+			backoff.DefaultBackoff,
 			db.GetDefaultRetrySettings(),
 		)
 		if err != nil {

--- a/pkg/icingadb/ha.go
+++ b/pkg/icingadb/ha.go
@@ -418,6 +418,7 @@ func (h *HA) realize(
 			return nil
 		},
 		retry.Retryable,
+		// Keep the maximum backoff time small and not use backoff.DefaultBackoff here.
 		backoff.NewExponentialWithJitter(256*time.Millisecond, 3*time.Second),
 		retry.Settings{
 			// Intentionally no timeout is set, as we use a context with a deadline.

--- a/pkg/icingadb/schema.go
+++ b/pkg/icingadb/schema.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 	"os"
 	"path"
-	"time"
 )
 
 const (
@@ -60,7 +59,7 @@ func CheckSchema(ctx context.Context, db *database.DB) error {
 			return nil
 		},
 		retry.Retryable,
-		backoff.NewExponentialWithJitter(128*time.Millisecond, 1*time.Minute),
+		backoff.DefaultBackoff,
 		db.GetDefaultRetrySettings())
 	if err != nil {
 		return errors.Wrap(err, "can't check database schema version")


### PR DESCRIPTION
Replace a custom backoff duration with backoff.DefaultBackoff introduced in the last IGL update[^0].

This was done for each occurrence except the one within the HA code, where a comment was added stating the reason. Since the HA.realize() method is bound by its context's deadline, introducing unnecessary delay may harm.

Fixes #965.

[^0]: https://github.com/Icinga/icinga-go-library/pull/133