### PR TITLE
Dedicated SQL Connection For Schema Import

### DIFF
--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -74,9 +74,19 @@ func run() int {
 		}
 
 		logger.Info("Starting database schema auto import")
+
+		db, err := cmd.Database(logs.GetChildLogger("database"))
+		if err != nil {
+			logger.Fatalw("Can't create database connection pool from config", zap.Error(err))
+		}
+		db.SetMaxOpenConns(1)
+
 		if err := icingadb.ImportSchema(context.Background(), db, cmd.Flags.DatabaseSchemaDir); err != nil {
 			logger.Fatalw("Can't import database schema", zap.Error(err))
 		}
+
+		_ = db.Close()
+
 		logger.Info("The database schema was successfully imported")
 	case err != nil:
 		logger.Fatalf("%+v", err)

--- a/pkg/icingadb/schema.go
+++ b/pkg/icingadb/schema.go
@@ -80,6 +80,9 @@ func CheckSchema(ctx context.Context, db *database.DB) error {
 // ImportSchema performs an initial schema import in the db.
 //
 // This function assumes that no schema exists. So it should only be called after a prior CheckSchema call.
+//
+// Note: Running a schema file may have side effects, such as altering SQL system variables. Unless you are certain that
+// the schema update will not interfere with future queries, consider using a dedicated database connection.
 func ImportSchema(
 	ctx context.Context,
 	db *database.DB,


### PR DESCRIPTION
Use a dedicated SQL connection for the schema import to eliminate side effects on future queries.

In particular, the MySQL/MariaDB schema file began by altering SQL system variables, such as "sql_mode". These changes persist throughout the entire connection, affecting every subsequent query.

Our database queries require the ANSI_QUOTES[0] SQL mode. However, the schema file had unset this mode, which resulted in failed queries and a subsequent Icinga DB crash. This was reported independently in #1002 and in the community forum[1].

Creating a short-lived, dedicated SQL connection for the schema import eliminates any impact on the main database connection.

Fixes #1002.

[0]: https://dev.mysql.com/doc/refman/8.4/en/sql-mode.html#sqlmode_ansi_quotes
[1]: https://community.icinga.com/t/error-1064-42000-you-have-an-error-in-your-sql-syntax-on-initialization/15080