### PR TITLE
Apply Go's modernized fixes

### DIFF
--- a/cmd/icingadb-migrate/convert.go
+++ b/cmd/icingadb-migrate/convert.go
@@ -52,7 +52,7 @@ type commentRow = struct {
 
 func convertCommentRows(
 	env string, envId types.Binary,
-	_ func(interface{}, string, ...interface{}), _ *sqlx.Tx, idoRows []commentRow,
+	_ func(any, string, ...any), _ *sqlx.Tx, idoRows []commentRow,
 ) (stages []icingaDbOutputStage, checkpoint any) {
 	var commentHistory, acknowledgementHistory, allHistoryComment, allHistoryAck []database.Entity
 
@@ -238,7 +238,7 @@ type downtimeRow = struct {
 
 func convertDowntimeRows(
 	env string, envId types.Binary,
-	_ func(interface{}, string, ...interface{}), _ *sqlx.Tx, idoRows []downtimeRow,
+	_ func(any, string, ...any), _ *sqlx.Tx, idoRows []downtimeRow,
 ) (stages []icingaDbOutputStage, checkpoint any) {
 	var downtimeHistory, allHistory, sla []database.Entity
 
@@ -395,7 +395,7 @@ type flappingRow = struct {
 
 func convertFlappingRows(
 	env string, envId types.Binary,
-	selectCache func(dest interface{}, query string, args ...interface{}), _ *sqlx.Tx, idoRows []flappingRow,
+	selectCache func(dest any, query string, args ...any), _ *sqlx.Tx, idoRows []flappingRow,
 ) (stages []icingaDbOutputStage, checkpoint any) {
 	if len(idoRows) < 1 {
 		return
@@ -449,7 +449,7 @@ func convertFlappingRows(
 		hostId := calcObjectId(env, row.Name1)
 		serviceId := calcServiceId(env, row.Name1, row.Name2)
 		startTime := float64(start.Time().UnixMilli())
-		flappingHistoryId := hashAny([]interface{}{env, name, startTime})
+		flappingHistoryId := hashAny([]any{env, name, startTime})
 
 		if row.EventType == 1001 { // end
 			// The start counterpart should already have been inserted.
@@ -475,7 +475,7 @@ func convertFlappingRows(
 			h := &history.HistoryFlapping{
 				HistoryMeta: history.HistoryMeta{
 					HistoryEntity: history.HistoryEntity{
-						Id: hashAny([]interface{}{env, "flapping_end", name, startTime}),
+						Id: hashAny([]any{env, "flapping_end", name, startTime}),
 					},
 					EnvironmentId: envId,
 					ObjectType:    typ,
@@ -512,7 +512,7 @@ func convertFlappingRows(
 			h := &history.HistoryFlapping{
 				HistoryMeta: history.HistoryMeta{
 					HistoryEntity: history.HistoryEntity{
-						Id: hashAny([]interface{}{env, "flapping_start", name, startTime}),
+						Id: hashAny([]any{env, "flapping_start", name, startTime}),
 					},
 					EnvironmentId: envId,
 					ObjectType:    typ,
@@ -553,7 +553,7 @@ type notificationRow = struct {
 
 func convertNotificationRows(
 	env string, envId types.Binary,
-	selectCache func(dest interface{}, query string, args ...interface{}), ido *sqlx.Tx, idoRows []notificationRow,
+	selectCache func(dest any, query string, args ...any), ido *sqlx.Tx, idoRows []notificationRow,
 ) (stages []icingaDbOutputStage, checkpoint any) {
 	if len(idoRows) < 1 {
 		return
@@ -628,8 +628,8 @@ func convertNotificationRows(
 
 		ts := convertTime(row.EndTime.Int64, row.EndTimeUsec)
 		tsMilli := float64(ts.Time().UnixMilli())
-		notificationHistoryId := hashAny([]interface{}{env, name, notificationType, tsMilli})
-		id := hashAny([]interface{}{env, "notification", name, notificationType, tsMilli})
+		notificationHistoryId := hashAny([]any{env, name, notificationType, tsMilli})
+		id := hashAny([]any{env, "notification", name, notificationType, tsMilli})
 		typ := objectTypes[row.ObjecttypeId]
 		hostId := calcObjectId(env, row.Name1)
 		serviceId := calcServiceId(env, row.Name1, row.Name2)
@@ -761,7 +761,7 @@ type stateRow = struct {
 
 func convertStateRows(
 	env string, envId types.Binary,
-	selectCache func(dest interface{}, query string, args ...interface{}), _ *sqlx.Tx, idoRows []stateRow,
+	selectCache func(dest any, query string, args ...any), _ *sqlx.Tx, idoRows []stateRow,
 ) (stages []icingaDbOutputStage, checkpoint any) {
 	if len(idoRows) < 1 {
 		return
@@ -797,8 +797,8 @@ func convertStateRows(
 		name := strings.Join([]string{row.Name1, row.Name2}, "!")
 		ts := convertTime(row.StateTime.Int64, row.StateTimeUsec)
 		tsMilli := float64(ts.Time().UnixMilli())
-		stateHistoryId := hashAny([]interface{}{env, name, tsMilli})
-		id := hashAny([]interface{}{env, "state_change", name, tsMilli})
+		stateHistoryId := hashAny([]any{env, name, tsMilli})
+		id := hashAny([]any{env, "state_change", name, tsMilli})
 		typ := objectTypes[row.ObjecttypeId]
 		hostId := calcObjectId(env, row.Name1)
 		serviceId := calcServiceId(env, row.Name1, row.Name2)

--- a/cmd/icingadb-migrate/misc.go
+++ b/cmd/icingadb-migrate/misc.go
@@ -21,7 +21,7 @@ type IdoMigrationProgressUpserter struct {
 }
 
 // Upsert implements the contracts.Upserter interface.
-func (impu *IdoMigrationProgressUpserter) Upsert() interface{} {
+func (impu *IdoMigrationProgressUpserter) Upsert() any {
 	return impu
 }
 
@@ -53,7 +53,7 @@ var log = func() *zap.SugaredLogger {
 var objectTypes = map[uint8]string{1: "host", 2: "service"}
 
 // hashAny combines objectpacker.PackAny and SHA1 hashing.
-func hashAny(in interface{}) []byte {
+func hashAny(in any) []byte {
 	hash := sha1.New() // #nosec G401 -- used as a non-cryptographic hash function to hash IDs
 	if err := objectpacker.PackAny(in, hash); err != nil {
 		panic(err)
@@ -97,10 +97,10 @@ func calcServiceId(env, name1, name2 string) []byte {
 // (On non-recoverable errors the whole program exits.)
 func sliceIdoHistory[Row any](
 	ht *historyType, query string, args map[string]any,
-	checkpoint interface{}, onRows func([]Row) (checkpoint interface{}),
+	checkpoint any, onRows func([]Row) (checkpoint any),
 ) {
 	if args == nil {
-		args = map[string]interface{}{}
+		args = map[string]any{}
 	}
 
 	args["fromid"] = ht.fromId

--- a/cmd/icingadb-migrate/misc.go
+++ b/cmd/icingadb-migrate/misc.go
@@ -225,7 +225,6 @@ type historyTypes []*historyType
 func (hts historyTypes) forEach(f func(*historyType)) {
 	eg, _ := errgroup.WithContext(context.Background())
 	for _, ht := range hts {
-		ht := ht
 		eg.Go(func() error {
 			f(ht)
 			return nil

--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -220,8 +220,6 @@ func run() int {
 
 						logger.Info("Starting config sync")
 						for _, factory := range v1.ConfigFactories {
-							factory := factory
-
 							configInitSync.Add(1)
 							g.Go(func() error {
 								defer configInitSync.Done()
@@ -231,8 +229,6 @@ func run() int {
 						}
 						logger.Info("Starting initial state sync")
 						for _, factory := range v1.StateFactories {
-							factory := factory
-
 							stateInitSync.Add(1)
 							g.Go(func() error {
 								defer stateInitSync.Done()

--- a/pkg/icingadb/delta_test.go
+++ b/pkg/icingadb/delta_test.go
@@ -229,7 +229,7 @@ func benchmarkDelta(b *testing.B, numEntities uint64) {
 		binary.BigEndian.PutUint64(e.PropertiesChecksum, checksum)
 		return e
 	}
-	for i := uint64(0); i < numEntities; i++ {
+	for i := range numEntities {
 		// each iteration writes exactly one entity to each channel
 		var eActual, eDesired database.Entity
 		switch i % 3 {

--- a/pkg/icingadb/delta_test.go
+++ b/pkg/icingadb/delta_test.go
@@ -129,9 +129,7 @@ func TestDelta(t *testing.T) {
 		nextId := uint64(1)
 		var wg sync.WaitGroup
 		for _, test := range tests {
-			test := test
 			for _, sendOrder := range sendOrders {
-				sendOrder := sendOrder
 				id := nextId
 				nextId++
 				// Log ID mapping to allow easier debugging in case of failures.

--- a/pkg/icingadb/entitiesbyid.go
+++ b/pkg/icingadb/entitiesbyid.go
@@ -19,8 +19,8 @@ func (ebi EntitiesById) Keys() []string {
 }
 
 // IDs returns the contracts.ID of the entities.
-func (ebi EntitiesById) IDs() []interface{} {
-	ids := make([]interface{}, 0, len(ebi))
+func (ebi EntitiesById) IDs() []any {
+	ids := make([]any, 0, len(ebi))
 	for _, v := range ebi {
 		ids = append(ids, v.(database.IDer).ID())
 	}

--- a/pkg/icingadb/entitiesbyid_test.go
+++ b/pkg/icingadb/entitiesbyid_test.go
@@ -96,8 +96,7 @@ func TestEntitiesById_Entities(t *testing.T) {
 
 	for _, st := range subtests {
 		t.Run(st.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
+			ctx := t.Context()
 
 			expected := make([]database.Entity, 0, len(st.io))
 			actual := make([]database.Entity, 0, len(st.io))

--- a/pkg/icingadb/history/retention.go
+++ b/pkg/icingadb/history/retention.go
@@ -107,7 +107,7 @@ type RetentionOptions map[string]uint16
 func (o *RetentionOptions) UnmarshalText(text []byte) error {
 	optionsMap := make(map[string]uint16)
 
-	for _, pair := range strings.Split(string(text), ",") {
+	for pair := range strings.SplitSeq(string(text), ",") {
 		key, value, found := strings.Cut(pair, ":")
 		if !found {
 			return fmt.Errorf("entry %q cannot be unmarshalled as a history-category:retention-period pair", pair)

--- a/pkg/icingadb/history/sync.go
+++ b/pkg/icingadb/history/sync.go
@@ -177,7 +177,7 @@ type stageFunc func(ctx context.Context, s Sync, key string, in <-chan redis.XMe
 // writeOneEntityStage creates a stageFunc from a pointer to a struct implementing the v1.UpserterEntity interface.
 // For each history event it receives, it parses that event into a new instance of that entity type and writes it to
 // the database. It writes exactly one entity to the database for each history event.
-func writeOneEntityStage(structPtr interface{}) stageFunc {
+func writeOneEntityStage(structPtr any) stageFunc {
 	structifier := structify.MakeMapStructifier(
 		reflect.TypeOf(structPtr).Elem(),
 		"json",

--- a/pkg/icingadb/history/sync.go
+++ b/pkg/icingadb/history/sync.go
@@ -41,9 +41,6 @@ func (s Sync) Sync(ctx context.Context) error {
 	g, ctx := errgroup.WithContext(ctx)
 
 	for key, pipeline := range syncPipelines {
-		key := key
-		pipeline := pipeline
-
 		s.logger.Debugf("Starting %s history sync", key)
 
 		// The pipeline consists of n+2 stages connected sequentially using n+1 channels of type chan redis.XMessage,
@@ -82,9 +79,6 @@ func (s Sync) Sync(ctx context.Context) error {
 		})
 
 		for i, stage := range pipeline {
-			i := i
-			stage := stage
-
 			g.Go(func() error {
 				return stage(ctx, s, key, ch[i], ch[i+1])
 			})

--- a/pkg/icingadb/runtime_updates.go
+++ b/pkg/icingadb/runtime_updates.go
@@ -73,16 +73,16 @@ func (r *RuntimeUpdates) Sync(
 
 		updateMessages := make(chan redis.XMessage, r.redis.Options.XReadCount)
 		upsertEntities := make(chan database.Entity, r.redis.Options.XReadCount)
-		deleteIds := make(chan interface{}, r.redis.Options.XReadCount)
+		deleteIds := make(chan any, r.redis.Options.XReadCount)
 
 		var upsertedFifo chan database.Entity
-		var deletedFifo chan interface{}
+		var deletedFifo chan any
 		var upsertCount int
 		var deleteCount int
 		upsertStmt, upsertPlaceholders := r.db.BuildUpsertStmt(s.Entity())
 		if !allowParallel {
 			upsertedFifo = make(chan database.Entity, 1)
-			deletedFifo = make(chan interface{}, 1)
+			deletedFifo = make(chan any, 1)
 			upsertCount = 1
 			deleteCount = 1
 		} else {
@@ -148,7 +148,7 @@ func (r *RuntimeUpdates) Sync(
 	{
 		updateMessages := make(chan redis.XMessage, r.redis.Options.XReadCount)
 		upsertEntities := make(chan database.Entity, r.redis.Options.XReadCount)
-		deleteIds := make(chan interface{}, r.redis.Options.XReadCount)
+		deleteIds := make(chan any, r.redis.Options.XReadCount)
 
 		cv := common.NewSyncSubject(v1.NewCustomvar)
 		cvFlat := common.NewSyncSubject(v1.NewCustomvarFlat)

--- a/pkg/icingadb/scoped_entity.go
+++ b/pkg/icingadb/scoped_entity.go
@@ -9,11 +9,11 @@ import (
 // enclosed entity type must satisfy in order to be SELECTed.
 type ScopedEntity struct {
 	database.Entity
-	scope interface{}
+	scope any
 }
 
 // Scope implements the contracts.Scoper interface.
-func (e ScopedEntity) Scope() interface{} {
+func (e ScopedEntity) Scope() any {
 	return e.scope
 }
 
@@ -23,7 +23,7 @@ func (e ScopedEntity) TableName() string {
 }
 
 // NewScopedEntity returns a new ScopedEntity.
-func NewScopedEntity(entity database.Entity, scope interface{}) *ScopedEntity {
+func NewScopedEntity(entity database.Entity, scope any) *ScopedEntity {
 	return &ScopedEntity{
 		Entity: entity,
 		scope:  scope,

--- a/pkg/icingadb/v1/customvar.go
+++ b/pkg/icingadb/v1/customvar.go
@@ -106,7 +106,7 @@ func flattenCustomvars(ctx context.Context, g *errgroup.Group, cvs <-chan databa
 		for i := 0; i < runtime.NumCPU(); i++ {
 			g.Go(func() error {
 				for entity := range cvs {
-					var value interface{}
+					var value any
 					customvar := entity.(*Customvar)
 					if err := types.UnmarshalJSON([]byte(customvar.Value), &value); err != nil {
 						return err
@@ -115,7 +115,7 @@ func flattenCustomvars(ctx context.Context, g *errgroup.Group, cvs <-chan databa
 					flattened := flatten.Flatten(value, customvar.Name)
 
 					for flatname, flatvalue := range flattened {
-						var fv interface{}
+						var fv any
 						if flatvalue.Valid {
 							fv = flatvalue.String
 						}

--- a/pkg/icingadb/v1/history/ack.go
+++ b/pkg/icingadb/v1/history/ack.go
@@ -14,7 +14,7 @@ type AckHistoryUpserter struct {
 }
 
 // Upsert implements the contracts.Upserter interface.
-func (ahu *AckHistoryUpserter) Upsert() interface{} {
+func (ahu *AckHistoryUpserter) Upsert() any {
 	return ahu
 }
 

--- a/pkg/icingadb/v1/history/comment.go
+++ b/pkg/icingadb/v1/history/comment.go
@@ -34,7 +34,7 @@ type CommentHistoryUpserter struct {
 }
 
 // Upsert implements the contracts.Upserter interface.
-func (chu *CommentHistoryUpserter) Upsert() interface{} {
+func (chu *CommentHistoryUpserter) Upsert() any {
 	return chu
 }
 

--- a/pkg/icingadb/v1/history/downtime.go
+++ b/pkg/icingadb/v1/history/downtime.go
@@ -33,7 +33,7 @@ type DowntimeHistoryUpserter struct {
 }
 
 // Upsert implements the contracts.Upserter interface.
-func (dhu *DowntimeHistoryUpserter) Upsert() interface{} {
+func (dhu *DowntimeHistoryUpserter) Upsert() any {
 	return dhu
 }
 
@@ -101,7 +101,7 @@ type SlaHistoryDowntimeUpserter struct {
 }
 
 // Upsert implements the contracts.Upserter interface.
-func (h *SlaHistoryDowntimeUpserter) Upsert() interface{} {
+func (h *SlaHistoryDowntimeUpserter) Upsert() any {
 	return h
 }
 

--- a/pkg/icingadb/v1/history/flapping.go
+++ b/pkg/icingadb/v1/history/flapping.go
@@ -16,7 +16,7 @@ type FlappingHistoryUpserter struct {
 }
 
 // Upsert implements the contracts.Upserter interface.
-func (fhu *FlappingHistoryUpserter) Upsert() interface{} {
+func (fhu *FlappingHistoryUpserter) Upsert() any {
 	return fhu
 }
 

--- a/pkg/icingadb/v1/history/meta.go
+++ b/pkg/icingadb/v1/history/meta.go
@@ -19,7 +19,7 @@ type HistoryTableEntity struct {
 
 // Upsert implements the contracts.Upserter interface.
 // Update only the Id (effectively nothing).
-func (hte HistoryTableEntity) Upsert() interface{} {
+func (hte HistoryTableEntity) Upsert() any {
 	return hte
 }
 
@@ -45,7 +45,7 @@ func (he *HistoryEntity) SetID(id database.ID) {
 
 // Upsert implements the contracts.Upserter interface.
 // Update only the Id (effectively nothing).
-func (he HistoryEntity) Upsert() interface{} {
+func (he HistoryEntity) Upsert() any {
 	return he
 }
 

--- a/pkg/icingadb/v1/history/notification.go
+++ b/pkg/icingadb/v1/history/notification.go
@@ -28,7 +28,7 @@ type UserNotificationHistory struct {
 	UserId                   types.Binary `json:"user_id"`
 }
 
-func (u *UserNotificationHistory) Upsert() interface{} {
+func (u *UserNotificationHistory) Upsert() any {
 	return u
 }
 

--- a/pkg/icingaredis/utils.go
+++ b/pkg/icingaredis/utils.go
@@ -26,7 +26,7 @@ func CreateEntities(ctx context.Context, factoryFunc database.EntityFactoryFunc,
 
 		g, ctx := errgroup.WithContext(ctx)
 
-		for i := 0; i < concurrent; i++ {
+		for range concurrent {
 			g.Go(func() error {
 				for {
 					select {
@@ -77,7 +77,7 @@ func SetChecksums(ctx context.Context, entities <-chan database.Entity, checksum
 
 		g, ctx := errgroup.WithContext(ctx)
 
-		for i := 0; i < concurrent; i++ {
+		for range concurrent {
 			g.Go(func() error {
 				for {
 					select {

--- a/pkg/icingaredis/utils_test.go
+++ b/pkg/icingaredis/utils_test.go
@@ -1,7 +1,6 @@
 package icingaredis
 
 import (
-	"context"
 	"github.com/icinga/icinga-go-library/database"
 	"github.com/icinga/icinga-go-library/redis"
 	"github.com/icinga/icingadb/pkg/icingadb/v1"
@@ -73,8 +72,7 @@ func TestCreateEntities(t *testing.T) {
 		t.Run(st.name, func(t *testing.T) {
 			for _, l := range latencies {
 				t.Run(l.name, func(t *testing.T) {
-					ctx, cancel := context.WithCancel(context.Background())
-					defer cancel()
+					ctx := t.Context()
 
 					input := make(chan redis.HPair, 1)
 					go func() {

--- a/pkg/icingaredis/v1/stats_message.go
+++ b/pkg/icingaredis/v1/stats_message.go
@@ -6,10 +6,10 @@ import (
 )
 
 // StatsMessage represents a message from the Redis stream icinga:stats.
-type StatsMessage map[string]interface{}
+type StatsMessage map[string]any
 
 // Raw returns the key-value pairs of the message.
-func (m StatsMessage) Raw() map[string]interface{} {
+func (m StatsMessage) Raw() map[string]any {
 	return m
 }
 


### PR DESCRIPTION
This PR applies the following modernized Go fixes made by the [Modernizer Analyzer tool](https://pkg.go.dev/golang.org/x/tools/gopls/internal/analysis/modernize) with each category fixes committed separately:

- 8eb9913 applies the `efaceany` category: replace interface{} by the 'any' type added in go1.18.
- 643d810 applies the `forvar` category: remove x := x variable declarations made unnecessary by the new semantics of loops in go1.22.
- 4e8db70 applies the `estingcontext` category: replace uses of context.WithCancel in tests with t.Context, added in go1.24.
- c9ebe8c applies the `rangeint` category: replace a 3-clause "for i := 0; i < n; i++" loop by "for i := range n", added in go1.22.
- and lastly ef18863 applies the `stringsseq` category: replace Split in "for range strings.Split(...)" by go1.24's more efficient SplitSeq, or Fields with FieldSeq.



