### PR TITLE
Release Icinga DB Version 1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Icinga DB Changelog
 
+## 1.5.0 (2025-11-18)
+
+The focus of this Icinga DB release is an integration with [Icinga Notifications](https://icinga.com/docs/icinga-notifications/latest/),
+which allows Icinga DB to act as an Icinga Notifications source.
+With the new [`notifications` configuration](https://icinga.com/docs/icinga-db/latest/doc/03-Configuration/#notifications-configuration) set,
+Icinga DB forwards events to Icinga Notifications.
+
+Additionally, maintenance work was completed.
+The most notable changes are as follows.
+
+* Introduce `notifications` to let Icinga DB forward events to Icinga Notifications. #998
+* Use a dedicated SQL connection for schema imports to prevent side effects on future queries. #1008
+* Modernize the Go codebase. #1013, #1026
+* Document PostgreSQL user usage for schema upgrades. #991
+
+### SELinux Policy
+
+The Icinga DB SELinux package, `icingadb-selinux`, has a new SELinux boolean, `icingadb_can_connect_all`,
+which allows outgoing TCP connections, such as to Icinga Notifications.
+
+When Icinga DB is used as an Icinga Notifications source, it submits events to the Icinga Notifications API.
+However, by default, Icinga DB's SELinux policy forbids outgoing TCP connections except to the relational database and Redis®.
+To enable event submission to Icinga Notifications, please set the `icingadb_can_connect_all` SELinux boolean.
+
+Note that the `icingadb-selinux` package is only available for Amazon Linux, Fedora, RHEL, openSUSE, and SLES.
+
 ## 1.4.0 (2025-06-18)
 
 This Icinga DB release introduces support for Icinga 2 dependencies, continues to retry certain long-persisting errors, and tweaks the logging.

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -185,6 +185,14 @@ ICINGADB_RETENTION_OPTIONS=comment:356
 Icinga DB can act as an event source for [Icinga Notifications](https://icinga.com/docs/icinga-notifications/).
 If configured, Icinga DB will submit events to the Icinga Notifications API.
 
+!!! important
+
+    When using Icinga DB with SELinux, please enable the `icingadb_can_connect_all` SELinux boolean to allow Icinga DB to connect to the Icinga Notifications API.
+
+    ```
+    setsebool -P icingadb_can_connect_all on
+    ```
+
 For YAML configuration, the options are part of the `notifications` dictionary.
 For environment variables, each option is prefixed with `ICINGADB_NOTIFICATIONS_`.
 

--- a/internal/version.go
+++ b/internal/version.go
@@ -7,4 +7,4 @@ import (
 // Version contains version and Git commit information.
 //
 // The placeholders are replaced on `git archive` using the `export-subst` attribute.
-var Version = version.Version("1.4.0", "$Format:%(describe)$", "$Format:%H$")
+var Version = version.Version("1.5.0", "$Format:%(describe)$", "$Format:%H$")


### PR DESCRIPTION
### TODO

* [x] Add https://git.icinga.com/packages/icingadb/-/merge_requests/16 (internal link only) to the changelog: Add the SELinux boolean `icingadb_can_connect_all` to allow Icinga DB to connect to Icinga Notifications.

Part of #1034.