### PR TITLE
Bump version of icinga-testing to use icinga/icinga2:edge container image

### DIFF
--- a/tests/go.mod
+++ b/tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/goccy/go-yaml v1.13.0
 	github.com/google/uuid v1.6.0
 	github.com/icinga/icinga-go-library v0.8.1
-	github.com/icinga/icinga-testing v0.0.0-20240322142451-494ccd6d03e8
+	github.com/icinga/icinga-testing v0.0.0-20251203103317-c39907077768
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/lib/pq v1.10.9
 	github.com/redis/go-redis/v9 v9.17.2

--- a/tests/go.sum
+++ b/tests/go.sum
@@ -72,8 +72,8 @@ github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0 h1:bkypFPDjIYGfCYD5mRBvpqxfYX1
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.20.0/go.mod h1:P+Lt/0by1T8bfcF3z737NnSbmxQAppXMRziHUxPOC8k=
 github.com/icinga/icinga-go-library v0.8.1 h1:l6YhSadzZaYowGjWrCWg2L35GVcDWbrdLgVbIDg1za4=
 github.com/icinga/icinga-go-library v0.8.1/go.mod h1:FlmUOqx3S5DKafphD9uvLVcP4SmlfkEW3hMWM8hm+0A=
-github.com/icinga/icinga-testing v0.0.0-20240322142451-494ccd6d03e8 h1:PI+39IY1BjN24JC3B6Jy0rhwm3hqC4SnQFxbZjXOaHk=
-github.com/icinga/icinga-testing v0.0.0-20240322142451-494ccd6d03e8/go.mod h1:xjNiwePgnSVKJWPG/iFG7pNOibU/OWp01Zdl08o+EeI=
+github.com/icinga/icinga-testing v0.0.0-20251203103317-c39907077768 h1:JeIfcuKWDWJ+qkUam16Edz1wEowFZd2JPWGFLPHgJ7E=
+github.com/icinga/icinga-testing v0.0.0-20251203103317-c39907077768/go.mod h1:xjNiwePgnSVKJWPG/iFG7pNOibU/OWp01Zdl08o+EeI=
 github.com/jmoiron/sqlx v1.4.0 h1:1PLqN7S1UYp5t4SrVVnt4nUVNemrDAtxlulVe+Qgm3o=
 github.com/jmoiron/sqlx v1.4.0/go.mod h1:ZrZ7UsYB/weZdl2Bxg6jCRO9c3YHl8r3ahlKmRT4JLY=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=


### PR DESCRIPTION
The Icinga 2 snapshot container images are no longer pushed as `icinga/icinga2:master` to Docker Hub but as `icinga/icinga2:edge` instead.

This fixes the following [error in our integration tests](https://github.com/Icinga/icingadb/actions/runs/19881989563) (happening since yesterday when the `master` tag was removed from Docker Hub, so that we and others notice it's no longer updated :sweat_smile:):

```
panic: Error response from daemon: manifest for icinga/icinga2:master not found: manifest unknown: manifest unknown [recovered, repanicked]
```

https://github.com/Icinga/icinga-testing/pull/33
https://github.com/Icinga/icinga2/pull/10505
https://icinga.com/blog/enhanced-icinga-2-container-images/