### PR TITLE
notifications: Close Prepared Statement

### DIFF
--- a/pkg/notifications/fetch.go
+++ b/pkg/notifications/fetch.go
@@ -94,6 +94,7 @@ func (client *Client) fetchCustomVarFromSql(
 		if err != nil {
 			return nil, err
 		}
+		defer func() { _ = stmt.Close() }()
 
 		var customVars []customVar
 		if err := stmt.SelectContext(ctx, &customVars, id); err != nil {


### PR DESCRIPTION
The prepared statement used to fetch custom vars from SQL for notification events is not closed. This results in leaking prepared statements, eventually resulting in the rejection of new prepared statements.

> notifications: Cannot build event from history entry error="cannot build event for \"[...]\",\"[...]\": Error 1461 (42000): Can't create more than max_prepared_stmt_count statements (current value: 16382)"

Monitoring MariaDB's `prepared_stmt_count` over roughly ten minutes before and after this change shows an increasing number of open prepared statements.

```
                                Before patch
 180 +-----------------------------------------------------------------+
     |       +        +       +       +       +        +     AAAA      |
 160 |-+                                                   AAA       +-|
     |                                                    AA           |
 140 |-+                                              AAAAA          +-|
     |                                             AAAA                |
 120 |-+                                         AAA                 +-|
     |                                       AAAAA                     |
 100 |-+                               AAAAAAA                       +-|
  80 |-+                            AAAA                             +-|
     |                             AA                                  |
  60 |-+                         AAA                                 +-|
     |                    AAAAAAAA                                     |
  40 |-+               AAAA                                          +-|
     |             AAAAA                                               |
  20 |-+        AAA                                                  +-|
     |       +AAA     +       +       +       +        +       +       |
   0 +-----------------------------------------------------------------+  9
1.76579 1.76579x 1.76579 1.76579 1.76579 1.76579x 1.76579 1.765 1.76579x10
                               Unix timestamp
```

The second graph, a record after the patch, contains measurements at the zero level.

```
                                 After patch
   1 +-----------------------------------------------------------------+
     |       +        +       +       +       +        +       +       |
     |                                                                 |
 0.8 |-+                                                             +-|
     |                                                                 |
     |                                                                 |
     |                                                                 |
 0.6 |-+                                                             +-|
     |                                                                 |
     |                                                                 |
 0.4 |-+                                                             +-|
     |                                                                 |
     |                                                                 |
     |                                                                 |
 0.2 |-+                                                             +-|
     |                                                                 |
     |       +        +       +       +       +        +       +       |
   0 +-----------------------------------------------------------------+  9
1.76579 1.76579x 1.76579 1.76579 1.76579 1.76579x 1.76579 1.765 1.76579x10
                                   Unix timestamp
```