### PR TITLE
overdue: Temporary Key in "icingadb:" Namespace

### DIFF
--- a/pkg/icingadb/overdue/get_overdues.lua
+++ b/pkg/icingadb/overdue/get_overdues.lua
@@ -1,7 +1,7 @@
 -- get_overdues.lua takes the following KEYS:
 -- * either icinga:nextupdate:host or icinga:nextupdate:service
 -- * either icingadb:overdue:host or icingadb:overdue:service
--- * a random one
+-- * a temporary one with a random name in the icingadb:temp namespace
 --
 -- It takes the following ARGV:
 -- * the current date and time as *nix timestamp float in seconds

--- a/pkg/icingadb/overdue/sync.go
+++ b/pkg/icingadb/overdue/sync.go
@@ -143,7 +143,7 @@ func (s Sync) sync(ctx context.Context, objectType string, factory factory, coun
 
 	keys := [3]string{"icinga:nextupdate:" + objectType, "icingadb:overdue:" + objectType, ""}
 	if rand, err := uuid.NewRandom(); err == nil {
-		keys[2] = rand.String()
+		keys[2] = "icingadb:temp:" + rand.String()
 	} else {
 		return errors.Wrap(err, "can't create random UUID")
 	}


### PR DESCRIPTION
The get_overdues.lua script uses a temporary Redis key to store data. So far, this key was a random UUID, not being prefixed or namespaced. This does not work when applying Redis ACLs on keys, as this random key is unpredictable. Now, this key is prefixed with "icingadb:temp:".

This was initially reported in the Community Forum[^0] where the user applied ACLs to the Redis user for Icinga DB.

It was easy to reproduce this by creating or reconfiguring a dedicated Redis user, allowing all operations on keys in the "icinga:" and "icingadb:" namespaces.

```
127.0.0.1:6380> ACL SETUSER icingadb on >icingadb ~icinga:* ~icingadb:* +@all
 OK
127.0.0.1:6380> ACL LIST
1) "user default on nopass sanitize-payload ~* &* +@all"
2) "user icingadb on sanitize-payload #1631be4f74353b72282ba144d82b6764f885feefc99c15c2c5f37b5c65bb3006 ~icinga:* ~icingadb:* resetchannels +@all"
```

After a while, the previous code failed as expected.

```
2026-01-07T11:22:10.253Z    FATAL   icingadb        NOPERM No permissions to access a key
can't execute Redis script
github.com/icinga/icingadb/pkg/icingadb/overdue.Sync.sync
    /go/src/github.com/Icinga/icingadb/pkg/icingadb/overdue/sync.go:164
github.com/icinga/icingadb/pkg/icingadb/overdue.Sync.Sync.func3
    /go/src/github.com/Icinga/icingadb/pkg/icingadb/overdue/sync.go:70
golang.org/x/sync/errgroup.(*Group).Go.func1
    /go/pkg/mod/golang.org/x/sync@v0.19.0/errgroup/errgroup.go:93
runtime.goexit
    /usr/local/go/src/runtime/asm_amd64.s:1700
```

With this change, Icinga DB only uses these two namespaces and continuous to operate.

[^0]: https://community.icinga.com/t/redis-user-acl-for-icingadb/15309