### PR TITLE
schema: Index user_notification_history.notification_history_id

### DIFF
--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -1142,7 +1142,9 @@ CREATE TABLE user_notification_history (
 
   PRIMARY KEY (id),
 
-  CONSTRAINT fk_user_notification_history_notification_history FOREIGN KEY (notification_history_id) REFERENCES notification_history (id) ON DELETE CASCADE
+  CONSTRAINT fk_user_notification_history_notification_history FOREIGN KEY (notification_history_id) REFERENCES notification_history (id) ON DELETE CASCADE,
+
+  INDEX idx_user_notification_history_notification_history_id (notification_history_id) COMMENT 'Speed up ON DELETE CASCADE'
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE state_history (

--- a/schema/mysql/upgrades/1.5.2-pr1059.sql
+++ b/schema/mysql/upgrades/1.5.2-pr1059.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_notification_history ADD INDEX idx_user_notification_history_notification_history_id (notification_history_id) COMMENT 'Speed up ON DELETE CASCADE';

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -1840,10 +1840,13 @@ ALTER TABLE user_notification_history ALTER COLUMN environment_id SET STORAGE PL
 ALTER TABLE user_notification_history ALTER COLUMN notification_history_id SET STORAGE PLAIN;
 ALTER TABLE user_notification_history ALTER COLUMN user_id SET STORAGE PLAIN;
 
+CREATE INDEX idx_user_notification_history_notification_history_id ON user_notification_history(notification_history_id);
+
 COMMENT ON COLUMN user_notification_history.id IS 'sha1(notification_history_id + user_id)';
 COMMENT ON COLUMN user_notification_history.environment_id IS 'environment.id';
 COMMENT ON COLUMN user_notification_history.notification_history_id IS 'UUID notification_history.id';
 COMMENT ON COLUMN user_notification_history.user_id IS 'user.id';
+COMMENT ON INDEX idx_user_notification_history_notification_history_id IS 'Speed up ON DELETE CASCADE';
 
 CREATE TABLE state_history (
   id bytea20 NOT NULL,

--- a/schema/pgsql/upgrades/1.5.2-pr1059.sql
+++ b/schema/pgsql/upgrades/1.5.2-pr1059.sql
@@ -1,0 +1,2 @@
+CREATE INDEX idx_user_notification_history_notification_history_id ON user_notification_history(notification_history_id);
+COMMENT ON INDEX idx_user_notification_history_notification_history_id IS 'Speed up ON DELETE CASCADE';


### PR DESCRIPTION
Add a new INDEX to user_notification_history.notification_history_id to speed up the notification history retention.

This column is a FOREIGN KEY to notification_history with a "ON DELETE CASCADE" clause. The notification_history table can be cleaned up by the notification retention, resulting in lots of DELETE queries. However, without the INDEX, the DELETE CASCADE might result in a full table scan for each retention operation.

I have further checked every other retention table, but no other had the same issue. Most retention tables have their primary key referenced by a foreign key in the history table, where indexes were already present.

Many thanks to @rezemble for both reporting this issue and coming up with the exact solution.

Fixes #1003.