### PR TITLE
Process customvar runtime updates only as part of the config udpates

### DIFF
--- a/pkg/icingadb/runtime_updates.go
+++ b/pkg/icingadb/runtime_updates.go
@@ -144,8 +144,8 @@ func (r *RuntimeUpdates) Sync(
 		})
 	}
 
-	// customvar and customvar_flat sync.
-	{
+	// customvar and customvar_flat sync don't need to be processed with state updates too.
+	if _, exists := streams["icinga:runtime"]; exists {
 		updateMessages := make(chan redis.XMessage, r.redis.Options.XReadCount)
 		upsertEntities := make(chan database.Entity, r.redis.Options.XReadCount)
 		deleteIds := make(chan any, r.redis.Options.XReadCount)


### PR DESCRIPTION
The `RuntimeUpdates::Sync` method is invoked twice, both for the normal runtime config and state updates. However, the customvars runtime updates processing logic was running in parallel in both invokations. There were already curly brackets around that code, probably because someone wanted to add some kind of condition for that, so I've add just added the missing condition for that.