### PR TITLE
HA: Always check realization context deadline

### DIFF
--- a/pkg/icingadb/ha.go
+++ b/pkg/icingadb/ha.go
@@ -210,8 +210,12 @@ func (h *HA) controller() {
 				realizeCtx, cancelRealizeCtx := context.WithDeadline(h.ctx, m.ExpiryTime())
 				err = h.realize(realizeCtx, s, envId, infoLogRoutineEvents)
 				cancelRealizeCtx()
-				if errors.Is(err, context.DeadlineExceeded) {
-					h.logger.Warnw("Instance update/insert exceeded heartbeat expiration time", zap.Error(err))
+				if errors.Is(realizeCtx.Err(), context.DeadlineExceeded) {
+					logFields := []any{zap.Error(realizeCtx.Err())}
+					if err != nil && !errors.Is(err, context.DeadlineExceeded) {
+						logFields = append(logFields, zap.NamedError("internal_error", err))
+					}
+					h.logger.Warnw("Instance update/insert exceeded heartbeat expiration time", logFields...)
 					h.signalHandover("instance update/insert deadline exceeded heartbeat expiry time")
 
 					// Instance insert/update was not completed by the expiration time of the current heartbeat.


### PR DESCRIPTION
The HA realization logic is bound to a context with a deadline based on the latest heartbeat message expiration time. Within the realize method, a database transaction is used - also honoring this context - within a retry.WithBackoff wrapper.

The retry.WithBackoff function returns the inner function's error, even when the context's deadline has exceeded. While this is intentional and useful, it might hide a relation to a context issue.

In this case, the exceeding context cancels the database transaction, resulting in a PostgreSQL cancellation, which is being returned as an error on its own.

> pq: canceling statement due to user request (57014)

When returning from the realize method, only the error is inspected, not the context with the deadline. Thus, the special case for an exceeded deadline is being skipped in this case.

---

Fixes #1137. This [comment in the issue](https://github.com/Icinga/icingadb/issues/1137#issuecomment-4788032904) explains a bit more about the reasoning.

I would be happy if you, @IPB-DevOps, are able to test this PR (in a non-production setup). Same goes for you, @nilmerg.