### PR TITLE
Transmit environment ID with events to Icinga Notifications

### DIFF
--- a/pkg/notifications/notifications.go
+++ b/pkg/notifications/notifications.go
@@ -161,6 +161,7 @@ func (client *Client) buildStateEvent(ctx context.Context, s *v1.State, hostId, 
 		return nil, errors.Wrapf(err, "cannot build event for %q,%q", hostId, serviceId)
 	}
 
+	ev.Tags["environment"] = s.EnvironmentId.String()
 	if s.Output.Valid {
 		ev.Message = s.Output.String
 	}


### PR DESCRIPTION
State events sent to Icinga Notifications were missing the environment ID. This adds it as the `environment` tag on every state change event, so the receiving side can scope notifications correctly to the originating environment.

  ## Changes
  
  - Set `ev.Tags["environment"]` from `s.EnvironmentId` in `buildStateEvent`

Resolves #1139 