### PR TITLE
notifications: use always `time.Now()` for event IDs

### DIFF
--- a/pkg/notifications/notifications.go
+++ b/pkg/notifications/notifications.go
@@ -285,7 +285,6 @@ func (client *Client) fetchIncidents(ctx context.Context) error {
 func (client *Client) buildCommonEvent(
 	ctx context.Context,
 	hostId, serviceId types.Binary,
-	eventTime types.UnixMilli,
 ) (*fetchableEvent, error) {
 	rel, err := client.fetchHostServiceData(ctx, hostId, serviceId)
 	if err != nil {
@@ -327,7 +326,7 @@ func (client *Client) buildCommonEvent(
 		}
 	}
 
-	objectId := objectName + fmt.Sprintf("!%d", eventTime.Time().UnixMilli())
+	objectId := objectName + fmt.Sprintf("!%d", time.Now().UnixMilli())
 
 	return &fetchableEvent{
 		Event: &event.Event{
@@ -348,7 +347,7 @@ var errNonVolatileNonHardState = errors.New("non-hard state change for non-volat
 // The resulted event will have all the necessary information for a state change event, and must
 // not be further modified by the caller.
 func (client *Client) buildStateEvent(ctx context.Context, s *v1.State, hostId, serviceId types.Binary) (*fetchableEvent, error) {
-	ev, err := client.buildCommonEvent(ctx, hostId, serviceId, s.LastStateChange)
+	ev, err := client.buildCommonEvent(ctx, hostId, serviceId)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot build event for %q,%q", hostId, serviceId)
 	}
@@ -421,7 +420,7 @@ func (client *Client) buildStateEvent(ctx context.Context, s *v1.State, hostId, 
 func (client *Client) buildDowntimeHistoryMetaEvent(ctx context.Context, h *v1history.DowntimeHistoryMeta) (*fetchableEvent, error) {
 	defer func() { panic("downtime history event generation is incomplete and not yet implemented") }()
 
-	ev, err := client.buildCommonEvent(ctx, h.HostId, h.ServiceId, types.UnixMilli{})
+	ev, err := client.buildCommonEvent(ctx, h.HostId, h.ServiceId)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot build event for %q,%q", h.HostId, h.ServiceId)
 	}
@@ -451,7 +450,7 @@ func (client *Client) buildDowntimeHistoryMetaEvent(ctx context.Context, h *v1hi
 func (client *Client) buildFlappingHistoryEvent(ctx context.Context, h *v1history.FlappingHistory) (*fetchableEvent, error) {
 	defer func() { panic("flapping history event generation is incomplete and not yet implemented") }()
 
-	ev, err := client.buildCommonEvent(ctx, h.HostId, h.ServiceId, types.UnixMilli{})
+	ev, err := client.buildCommonEvent(ctx, h.HostId, h.ServiceId)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot build event for %q,%q", h.HostId, h.ServiceId)
 	}
@@ -475,7 +474,7 @@ func (client *Client) buildFlappingHistoryEvent(ctx context.Context, h *v1histor
 func (client *Client) buildAcknowledgementHistoryEvent(ctx context.Context, h *v1history.AcknowledgementHistory) (*fetchableEvent, error) {
 	defer func() { panic("acknowledgement history event generation is incomplete and not yet implemented") }()
 
-	ev, err := client.buildCommonEvent(ctx, h.HostId, h.ServiceId, types.UnixMilli{})
+	ev, err := client.buildCommonEvent(ctx, h.HostId, h.ServiceId)
 	if err != nil {
 		return nil, errors.Wrapf(err, "cannot build event for %q,%q", h.HostId, h.ServiceId)
 	}


### PR DESCRIPTION
Previously, the LastStateChange column was used to generate the event ID, but this is not reliable for events other than state changes, as the checkable can be ACKED, set in Downtime etc. while still being in the same problem state, thus the LastStateChange timestamp does not change. So, we now use the current timestamp in milliseconds to generate a unique event ID for each event, as everything sent to Icinga Notifications is considered a new event, even if the checkable is still in the same state.

I've just merged #1148 without actually testing it, I only noticed this again when I was testing the HA related in Icinga Notifications.