### PR TITLE
Probe notifications socket & monitor API health

### DIFF
--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -177,7 +177,8 @@ func run() int {
 			db,
 			rc,
 			logs.GetChildLogger("notifications"),
-			cfg)
+			cfg,
+			ha.NotificationsHeartbeat())
 		if err != nil {
 			logger.Fatalw("Can't create Icinga Notifications client from config", zap.Error(err))
 		}

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -181,11 +181,12 @@ ICINGADB_RETENTION_OPTIONS=comment:356
 
 ## Notifications Configuration
 
-!!! warning
+!!! tip
 
-    The Icinga Notifications integration is a feature preview that you can try out.
-    However, incompatible changes may happen, so be sure to check the changelog for future updates.
-    Please do not use it in production.
+    If the `ICINGA_NOTIFICATIONS_LISTENER_SOCKET` environment variable is set, Icinga DB will automatically detect the
+    Icinga Notifications API Unix Domain Socket availability and persist the result in the database. This allows
+    Icinga DB Web to provide a one-click configure button for Icinga Notifications, which will automatically configure
+    this component, and create the corresponding Icinga Notifications source configuration on your behalf.
 
 Icinga DB can act as an event source for [Icinga Notifications](https://icinga.com/docs/icinga-notifications/).
 If configured, Icinga DB will submit events to the Icinga Notifications API.

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/vbauerster/mpb/v6 v6.0.4
 	go.uber.org/zap v1.28.0
 	golang.org/x/sync v0.22.0
+	golang.org/x/sys v0.30.0
 )
 
 require (
@@ -40,6 +41,5 @@ require (
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/exp v0.0.0-20240506185415-9bf2ced13842 // indirect
-	golang.org/x/sys v0.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/icingadb/ha.go
+++ b/pkg/icingadb/ha.go
@@ -18,6 +18,10 @@ import (
 	icingaredisv1 "github.com/icinga/icingadb/pkg/icingaredis/v1"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
+	"golang.org/x/sys/unix"
+	"os"
+	"os/user"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -32,6 +36,25 @@ type haState struct {
 	responsibleTsMilli int64
 	responsible        bool
 	otherResponsible   bool
+}
+
+// NotificationsState holds the current state of the Icinga Notifications component.
+type NotificationsState struct {
+	unhealthySince time.Time // The time when the Icinga Notifications component was first detected as unhealthy.
+	healthy        types.Bool
+
+	// The discovered Icinga Notifications listener socket path, if any.
+	socketPath types.String
+
+	// lastProblemLoggedAt is the last time a problem with the Icinga Notifications component was logged.
+	// This is used to suppress recurring log messages.
+	lastProblemLoggedAt time.Time
+}
+
+// IsValidUnhealthy returns true if the healthy state is valid and set to false, indicating that the
+// Icinga Notifications component is unhealthy.
+func (ns *NotificationsState) IsValidUnhealthy() bool {
+	return ns.healthy.Valid && !ns.healthy.Bool
 }
 
 // HA provides high availability and indicates whether a Takeover or Handover must be made.
@@ -52,6 +75,13 @@ type HA struct {
 	errOnce       sync.Once
 	errMu         sync.Mutex
 	err           error
+
+	// notificationsHeartbeat is a channel that signals the status of the Icinga Notifications component.
+	//
+	// This will only receive events when the Icinga Notifications component is enabled, and its true value indicates
+	// that the component is healthy and able to process notifications, while a false value indicates that it is not.
+	notificationsHeartbeatCh chan bool
+	notifications            NotificationsState
 }
 
 // NewHA returns a new HA and starts the controller loop.
@@ -70,6 +100,8 @@ func NewHA(ctx context.Context, db *database.DB, heartbeat *icingaredis.Heartbea
 		handover:   make(chan string),
 		takeover:   make(chan string),
 		done:       make(chan struct{}),
+
+		notificationsHeartbeatCh: make(chan bool),
 	}
 
 	ha.state.Store(&haState{})
@@ -122,6 +154,12 @@ func (h *HA) Takeover() chan string {
 	return h.takeover
 }
 
+// NotificationsHeartbeat returns a channel to send the status of Icinga Notifications component into.
+//
+// The channel is used to signal the health of the Icinga Notifications component, where a true value indicates
+// that the component is healthy and able to process notifications, while a false value indicates that it is not.
+func (h *HA) NotificationsHeartbeat() chan<- bool { return h.notificationsHeartbeatCh }
+
 // State returns the status quo.
 func (h *HA) State() (responsibleTsMilli int64, responsible, otherResponsible bool) {
 	state := h.state.Load()
@@ -173,6 +211,12 @@ func (h *HA) controller() {
 
 					continue
 				}
+
+				// Returns true when a handover has been triggered, and we should skip the rest of the loop.
+				if h.verifyNotificationsState() {
+					continue
+				}
+
 				s, err := m.Stats().IcingaStatus()
 				if err != nil {
 					h.abort(err)
@@ -237,6 +281,16 @@ func (h *HA) controller() {
 				h.signalHandover("lost heartbeat")
 				h.realizeLostHeartbeat()
 			}
+
+		case healthy := <-h.notificationsHeartbeatCh:
+			h.logger.Debugw("Received notifications heartbeat", zap.Bool("healthy", healthy))
+			h.notifications.healthy = types.MakeBool(healthy)
+			if healthy {
+				h.notifications.unhealthySince = time.Time{}
+			} else if h.notifications.unhealthySince.IsZero() {
+				h.notifications.unhealthySince = time.Now()
+			}
+
 		case <-h.heartbeat.Done():
 			if err := h.heartbeat.Err(); err != nil {
 				h.abort(err)
@@ -365,6 +419,9 @@ func (h *HA) realize(
 				Icinga2FlapDetectionEnabled:       s.FlapDetectionEnabled,
 				Icinga2PerformanceDataEnabled:     s.PerformanceDataEnabled,
 				IcingadbVersion:                   internal.Version.Version,
+				IcingadbServiceUser:               ServiceUser(),
+				NotificationsHealthy:              h.notifications.healthy,
+				NotificationsDiscoveredSocketPath: h.probeNotificationsSocketPath(),
 			}
 
 			stmt, _ := h.db.BuildUpsertStmt(i)
@@ -480,10 +537,21 @@ func (h *HA) realize(
 	return nil
 }
 
+// instanceCount returns the number of instances in the current environment.
+func (h *HA) instanceCount() int64 {
+	query := h.db.Rebind("SELECT COUNT(*) FROM icingadb_instance WHERE environment_id = ?")
+	var count int64
+	if err := h.db.GetContext(h.ctx, &count, query, h.environment.Id); err != nil {
+		h.logger.Warnw("Cannot count instances", zap.Error(database.CantPerformQuery(err, query)))
+		return 0
+	}
+	return count
+}
+
 // realizeLostHeartbeat updates "responsible = n" for this HA into the database.
 func (h *HA) realizeLostHeartbeat() {
-	stmt := h.db.Rebind("UPDATE icingadb_instance SET responsible = ? WHERE id = ?")
-	if _, err := h.db.ExecContext(h.ctx, stmt, "n", h.instanceId); err != nil && !utils.IsContextCanceled(err) {
+	stmt := h.db.Rebind("UPDATE icingadb_instance SET responsible = ?, notifications_healthy = ? WHERE id = ?")
+	if _, err := h.db.ExecContext(h.ctx, stmt, "n", h.notifications.healthy, h.instanceId); err != nil && !utils.IsContextCanceled(err) {
 		h.logger.Warnw("Can't update instance", zap.Error(database.CantPerformQuery(err, stmt)))
 	}
 }
@@ -557,5 +625,82 @@ func (h *HA) signalTakeover(reason string) {
 		case <-h.ctx.Done():
 			// Noop
 		}
+	}
+}
+
+// verifyNotificationsState checks the state of the Icinga Notifications component and triggers a handover if necessary.
+//
+// It returns true if a handover was triggered, false otherwise.
+func (h *HA) verifyNotificationsState() bool {
+	now := time.Now()
+	if h.notifications.IsValidUnhealthy() && now.After(h.notifications.unhealthySince.Add(retry.DefaultTimeout)) {
+		lastLogged := h.notifications.lastProblemLoggedAt
+		if lastLogged.IsZero() || now.After(lastLogged.Add(retry.DefaultTimeout)) {
+			h.logger.Errorw("Icinga Notifications component has been unhealthy for a long time",
+				zap.Time("unhealthy_since", h.notifications.unhealthySince))
+		}
+		h.notifications.lastProblemLoggedAt = now
+
+		// If we're indeed running in a multi-instance environment, we should hand over responsibility
+		// to another instance, otherwise there's no other instance to take over, so we let this retry
+		// its connection attempts to the Icinga Notifications API.
+		if h.instanceCount() > 1 {
+			h.signalHandover("notifications component has been unhealthy for a long time")
+			h.realizeLostHeartbeat()
+
+			// Reset the notifications state, so that we have a fresh start when this instance regains responsibility.
+			h.notifications = NotificationsState{}
+
+			return true
+		}
+	} else {
+		h.notifications.lastProblemLoggedAt = time.Time{}
+	}
+
+	return false
+}
+
+// probeNotificationsSocketPath checks the availability of the Icinga Notifications listener socket and returns
+// its path if available.
+func (h *HA) probeNotificationsSocketPath() (socketPath types.String) {
+	if h.notifications.socketPath.Valid && h.notifications.socketPath.String != "" {
+		return h.notifications.socketPath
+	}
+	defer func() { h.notifications.socketPath = socketPath }()
+
+	path := os.Getenv("ICINGA_NOTIFICATIONS_LISTENER_SOCKET")
+	if path == "" {
+		h.logger.Debugw("Cannot probe Icinga Notifications listener socket availability: ICINGA_NOTIFICATIONS_LISTENER_SOCKET is not set")
+		return types.MakeString("", types.TransformEmptyStringToNull)
+	}
+
+	path = filepath.Clean(path)
+	info, err := os.Stat(path)
+	if err != nil {
+		h.logger.Warnw("Failed to stat Icinga Notifications listener socket", zap.String("path", path), zap.Error(err))
+		return types.MakeString("", types.TransformEmptyStringToNull)
+	}
+
+	if info.Mode()&os.ModeSocket == 0 {
+		h.logger.Warnw("Icinga Notifications listener socket path is not a socket", zap.String("path", path))
+		return types.MakeString("", types.TransformEmptyStringToNull)
+	}
+
+	if err := unix.Access(path, unix.R_OK|unix.W_OK); err != nil {
+		h.logger.Warnw("Icinga DB user has no permissions to access Icinga Notifications listener socket",
+			zap.String("path", path), zap.Error(err))
+		return types.MakeString("", types.TransformEmptyStringToNull)
+	}
+
+	h.logger.Debugw("Successfully probed Icinga Notifications listener socket availability", zap.String("path", path))
+	return types.MakeString(path)
+}
+
+// ServiceUser returns the name the service user the process is running as.
+func ServiceUser() string {
+	if currentUser, err := user.Current(); err != nil {
+		return "unknown"
+	} else {
+		return currentUser.Username
 	}
 }

--- a/pkg/icingadb/v1/icingadb_instance.go
+++ b/pkg/icingadb/v1/icingadb_instance.go
@@ -19,4 +19,7 @@ type IcingadbInstance struct {
 	Icinga2FlapDetectionEnabled       types.Bool      `json:"icinga2_flap_detection_enabled"`
 	Icinga2PerformanceDataEnabled     types.Bool      `json:"icinga2_performance_data_enabled"`
 	IcingadbVersion                   string          `json:"-"`
+	IcingadbServiceUser               string          `json:"-"`
+	NotificationsHealthy              types.Bool      `json:"-"`
+	NotificationsDiscoveredSocketPath types.String    `json:"-"`
 }

--- a/pkg/notifications/notifications.go
+++ b/pkg/notifications/notifications.go
@@ -77,6 +77,9 @@ type Client struct {
 	// incidentsByObjId is a map of object IDs to incidents populated by the first call to ApplyDelta.
 	incidentsByObjId map[string]source.Incident
 	incidentsMu      sync.Mutex
+
+	// heartbeatOutCh is a channel used to send heartbeat signals to the HA controller.
+	heartbeatOutCh chan<- bool
 }
 
 // NewNotificationsClient creates a new Client connected to an existing database and logger.
@@ -85,6 +88,7 @@ func NewNotificationsClient(
 	rc *redis.Client,
 	logger *logging.Logger,
 	cfg source.Config,
+	heartbeatOutCh chan<- bool,
 ) (*Client, error) {
 	notificationsClient, err := source.NewClient(cfg, "Icinga DB "+internal.Version.Version)
 	if err != nil {
@@ -99,6 +103,8 @@ func NewNotificationsClient(
 
 		notificationsClient: notificationsClient,
 		redisClient:         rc,
+
+		heartbeatOutCh: heartbeatOutCh,
 	}, nil
 }
 
@@ -124,10 +130,19 @@ func (client *Client) ClearIncidents() {
 // This function is called by the initial config dump after the delta has been calculated. It fetches the current
 // incidents from the Icinga Notifications API and compares them with the delta. If there are any changes, it submits
 // the new or updated events to the API and closes any incidents for deleted objects.
+//
+// Returns an error only when the provided context is canceled or Redis is unavailable. Otherwise, it will log any
+// errors encountered during the submission of events to the Icinga Notifications API and continue processing the
+// remaining events, but never returns an error for those.
 func (client *Client) ApplyDelta(ctx context.Context, delta *icingadb.Delta) error {
 	switch delta.Subject.Entity().(type) {
 	case *v1.HostState, *v1.ServiceState:
 	default:
+		return nil
+	}
+
+	client.fetchIncidents(ctx)
+	if len(client.incidentsByObjId) == 0 {
 		return nil
 	}
 
@@ -136,10 +151,6 @@ func (client *Client) ApplyDelta(ctx context.Context, delta *icingadb.Delta) err
 		zap.Int("deleted", len(delta.Delete)),
 		zap.Int("new", len(delta.Create)),
 		zap.Int("updated", len(delta.Update)))
-
-	if err := client.fetchIncidents(ctx); err != nil {
-		return err
-	}
 
 	g, ctx := errgroup.WithContext(ctx)
 	if len(delta.Create) > 0 || len(delta.Update) > 0 {
@@ -184,11 +195,14 @@ func (client *Client) ApplyDelta(ctx context.Context, delta *icingadb.Delta) err
 						}
 					}
 
-					// If the entity is new or has a different state than the existing incident, submit it to
-					// Icinga Notifications via the regular /process-event endpoint.
-					if err := client.Submit(ctx, entity); err != nil {
-						return err
-					}
+					// If the entity is new or has a different state than the existing incident, submit it to Icinga
+					// Notifications via the regular /process-event endpoint. Though, in case the API isn't healthy,
+					// it will retry it endlessly, so set a timeout to avoid blocking the entire config dump.
+					func() {
+						ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+						defer cancel()
+						_ = client.Submit(ctx, entity)
+					}()
 				}
 			}
 		})
@@ -222,7 +236,10 @@ func (client *Client) ApplyDelta(ctx context.Context, delta *icingadb.Delta) err
 
 		attrs := source.ModifiableIncidentAttrs{Close: types.MakeBool(true)}
 		if err := client.notificationsClient.ModifyIncidents(ctx, attrs, filter); err != nil {
-			return errors.Wrap(err, "cannot close incidents for deleted objects")
+			client.logger.Errorw("Failed to bulk close obsolete incidents for deleted objects",
+				zap.String("entity", delta.Subject.Name()),
+				zap.Int("count", len(filter)),
+				zap.String("error", err.Error()))
 		}
 		return nil
 	})
@@ -233,24 +250,26 @@ func (client *Client) ApplyDelta(ctx context.Context, delta *icingadb.Delta) err
 // fetchIncidents fetches all incidents from the Icinga Notifications API and stores them in the Client's incidentsByObjId map.
 //
 // If the incidents have already been fetched, this function does nothing. This function is safe to call concurrently.
-func (client *Client) fetchIncidents(ctx context.Context) error {
+func (client *Client) fetchIncidents(ctx context.Context) {
 	client.incidentsMu.Lock()
 	defer client.incidentsMu.Unlock()
 
 	// ApplyDelta is called in parallel for each entity type, so we need to ensure
 	// that we only fetch the incidents once per environment.
 	if client.incidentsByObjId != nil {
-		return nil
+		return
 	}
 
 	environment, ok := v1.EnvironmentFromContext(ctx)
 	if !ok {
-		return errors.New("cannot get environment from context")
+		panic("cannot get environment from context")
 	}
 
 	incidents, err := client.notificationsClient.GetIncidents(ctx, map[string]string{"environment": environment.ID().String()})
 	if err != nil {
-		return err
+		client.sendHeartbeat(false)
+		client.logger.Errorw("Failed to fetch incidents", zap.String("error", err.Error()))
+		return
 	}
 
 	client.incidentsByObjId = make(map[string]source.Incident)
@@ -260,19 +279,30 @@ func (client *Client) fetchIncidents(ctx context.Context) error {
 		// related object IDs, so make sure to keep it in sync with the Icinga 2 implementation.
 		//
 		// [^1]: https://github.com/Icinga/icinga2/blob/v2.16.3/lib/icingadb/icingadb-utility.cpp#L81
-		idTags := []any{environment.ID().String()}
+		idTags := []string{environment.ID().String()}
 		if service, ok := incident.ObjectTags["service"]; ok {
 			idTags = append(idTags, incident.ObjectTags["host"]+"!"+service)
 		} else {
 			idTags = append(idTags, incident.ObjectTags["host"])
 		}
 		if err := objectpacker.PackAny(idTags, hash); err != nil {
-			return err
+			client.logger.Warnw("Cannot pack incident object ID for hashing, skipping incident",
+				zap.Strings("id_tags", idTags),
+				zap.Error(err))
+			continue
 		}
 		client.incidentsByObjId[hex.EncodeToString(hash.Sum(nil))] = incident
 		hash.Reset()
 	}
-	return nil
+}
+
+// sendHeartbeat sends a heartbeat signal to the HA controller via the heartbeatOutCh channel.
+func (client *Client) sendHeartbeat(alive bool) {
+	select {
+	case client.heartbeatOutCh <- alive:
+	default:
+		client.logger.Debugw("Heartbeat channel is full, dropping signal", zap.Bool("healthy", alive))
+	}
 }
 
 // buildCommonEvent creates an event.Event based on Host and (optional) Service IDs.
@@ -568,7 +598,7 @@ func (client *Client) Submit(ctx context.Context, entity database.Entity) error 
 		client.logger.Errorw("BUG: generated event is invalid, skipping submission",
 			zap.Any("event", ev.Event),
 			zap.Any("entity", entity),
-			zap.Error(err))
+			zap.String("error", err.Error()))
 		return nil
 	}
 
@@ -582,11 +612,7 @@ func (client *Client) Submit(ctx context.Context, entity database.Entity) error 
 						zap.String("event", ev.Name),
 						zap.Strings("attributes", attributes),
 						zap.Error(err))
-
-					// ev.completeAndUpdate retries any retryable errors internally, so if we get an error here,
-					// it means that we cannot complete the event with the given attributes, so we should not retry
-					// anymore. Therefore, we return a non-retryable error here instead of propagating the original one.
-					return errors.New("cannot complete event relations")
+					return err
 				}
 
 				attributes, err = client.notificationsClient.ProcessEvent(ctx, ev.Event, true)
@@ -599,11 +625,11 @@ func (client *Client) Submit(ctx context.Context, entity database.Entity) error 
 				return err
 			}
 		},
-		retry.Retryable,
+		func(err error) bool { return true }, // Retry all errors.
 		backoff.DefaultBackoff,
 		retry.Settings{
-			Timeout: retry.DefaultTimeout,
 			OnSuccess: func(elapsed time.Duration, attempt uint64, lastErr error) {
+				client.sendHeartbeat(true)
 				telemetry.Stats.NotificationSync.Add(1)
 
 				client.logger.Debugw("Successfully submitted event to Icinga Notifications",
@@ -613,11 +639,15 @@ func (client *Client) Submit(ctx context.Context, entity database.Entity) error 
 					zap.Error(lastErr))
 			},
 			OnRetryableError: func(elapsed time.Duration, attempt uint64, err, lastErr error) {
-				client.logger.Warnw("Cannot submit event to Icinga Notifications",
-					zap.String("event", ev.Name),
-					zap.Uint64("attempt", attempt),
-					zap.Duration("elapsed", elapsed),
-					zap.Error(err))
+				client.sendHeartbeat(false)
+
+				if lastErr == nil || err.Error() != lastErr.Error() {
+					client.logger.Errorw("Cannot submit event to Icinga Notifications",
+						zap.String("event", ev.Name),
+						zap.Uint64("attempt", attempt),
+						zap.Duration("elapsed", elapsed),
+						zap.Error(err))
+				}
 			},
 		},
 	)

--- a/pkg/notifications/notifications.go
+++ b/pkg/notifications/notifications.go
@@ -5,7 +5,9 @@ import (
 	"crypto/sha1" // #nosec G505 -- Blocklisted import crypto/sha1
 	"encoding/hex"
 	"fmt"
+	"maps"
 	"reflect"
+	"slices"
 	"sync"
 	"time"
 
@@ -146,67 +148,52 @@ func (client *Client) ApplyDelta(ctx context.Context, delta *icingadb.Delta) err
 		return nil
 	}
 
-	client.logger.Debugw("Applying delta to Icinga Notifications",
-		zap.String("entity", delta.Subject.Name()),
-		zap.Int("deleted", len(delta.Delete)),
-		zap.Int("new", len(delta.Create)),
-		zap.Int("updated", len(delta.Update)))
+	client.logger.Infof("Fetching %d entities of type %s from Redis for submission to Icinga Notifications",
+		len(delta.RedisSnapshot),
+		delta.Subject.Name())
 
 	g, ctx := errgroup.WithContext(ctx)
-	if len(delta.Create) > 0 || len(delta.Update) > 0 {
-		client.logger.Infof("Fetching %d entities of type %s from Redis for submission to Icinga Notifications",
-			len(delta.Create)+len(delta.Update),
-			delta.Subject.Name())
+	pairs, errs := client.redisClient.HMYield(
+		ctx,
+		fmt.Sprintf("icinga:%s", strcase.Delimited(types.Name(delta.Subject.Entity()), ':')),
+		slices.Collect(maps.Keys(delta.RedisSnapshot))...,
+	)
+	com.ErrgroupReceive(g, errs)
 
-		pairs, errs := client.redisClient.HMYield(
-			ctx,
-			fmt.Sprintf("icinga:%s", strcase.Delimited(types.Name(delta.Subject.Entity()), ':')),
-			append(delta.Update.Keys(), delta.Create.Keys()...)...,
-		)
-		com.ErrgroupReceive(g, errs)
+	entities, rErrs := icingaredis.CreateEntities(ctx, delta.Subject.Factory(), pairs, 1)
+	com.ErrgroupReceive(g, rErrs)
 
-		entities, rErrs := icingaredis.CreateEntities(ctx, delta.Subject.Factory(), pairs, 1)
-		com.ErrgroupReceive(g, rErrs)
-
-		g.Go(func() error {
-			for {
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case entity, ok := <-entities:
-					if !ok {
-						return nil
-					}
-
-					if _, exists := delta.Update[entity.ID().String()]; exists {
-						incident, ok := client.incidentsByObjId[entity.ID().String()]
-						client.logger.Debugw("Delta update for entity",
-							zap.String("entity", entity.ID().String()),
-							zap.Bool("incident_exists", ok))
-
-						if ok {
-							if same, err := HaveSameState(incident, entity); err != nil {
-								return err
-							} else if same {
-								// Should we send a message update here too or just wait for the timer to expire
-								// and sync the message accordingly? See https://github.com/Icinga/icingadb/issues/1140
-								continue
-							}
-						}
-					}
-
-					// If the entity is new or has a different state than the existing incident, submit it to Icinga
-					// Notifications via the regular /process-event endpoint. Though, in case the API isn't healthy,
-					// it will retry it endlessly, so set a timeout to avoid blocking the entire config dump.
-					func() {
-						ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
-						defer cancel()
-						_ = client.Submit(ctx, entity)
-					}()
+	g.Go(func() error {
+		for {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case entity, ok := <-entities:
+				if !ok {
+					return nil
 				}
+
+				if incident, exists := client.incidentsByObjId[entity.ID().String()]; exists {
+					if same, err := HaveSameState(incident, entity); err != nil {
+						return err
+					} else if same {
+						// Should we send a message update here too or just wait for the timer to expire
+						// and sync the message accordingly? See https://github.com/Icinga/icingadb/issues/1140
+						continue
+					}
+				}
+
+				// If the entity is new or has a different state than the existing incident, submit it to Icinga
+				// Notifications via the regular /process-event endpoint. Though, in case the API isn't healthy,
+				// it will retry it endlessly, so set a timeout to avoid blocking the entire config dump.
+				func() {
+					ctx, cancel := context.WithTimeout(ctx, 3*time.Second)
+					defer cancel()
+					_ = client.Submit(ctx, entity)
+				}()
 			}
-		})
-	}
+		}
+	})
 
 	g.Go(func() error {
 		var filter []any

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -550,6 +550,9 @@ CREATE TABLE icingadb_instance (
   icinga2_performance_data_enabled enum('n', 'y') NOT NULL,
 
   icingadb_version varchar(255) NOT NULL,
+  icingadb_service_user varchar(255) NOT NULL, -- see https://systemd.io/USER_NAMES/ for the restrictions on usernames.
+  notifications_healthy enum('n', 'y') DEFAULT NULL, -- NULL means unknown, n means unhealthy, y means healthy.
+  notifications_discovered_socket_path mediumtext, -- The discovered Icinga Notifications socket path, if any.
 
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;

--- a/schema/mysql/upgrades/notifications-health-and-discovery.sql
+++ b/schema/mysql/upgrades/notifications-health-and-discovery.sql
@@ -1,0 +1,6 @@
+ALTER TABLE icingadb_instance
+  ADD COLUMN icingadb_service_user varchar(255) NOT NULL DEFAULT 'icingadb',
+  ADD COLUMN notifications_healthy enum('n', 'y') DEFAULT NULL,
+  ADD COLUMN notifications_discovered_socket_path mediumtext;
+
+ALTER TABLE icingadb_instance MODIFY COLUMN icingadb_service_user varchar(255) NOT NULL;

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -801,6 +801,9 @@ CREATE TABLE icingadb_instance (
   icinga2_performance_data_enabled boolenum NOT NULL DEFAULT 'n',
 
   icingadb_version varchar(255) NOT NULL,
+  icingadb_service_user varchar(255) NOT NULL, -- see https://systemd.io/USER_NAMES/ for the restrictions on usernames.
+  notifications_healthy boolenum DEFAULT NULL, -- NULL means unknown, n means unhealthy, y means healthy.
+  notifications_discovered_socket_path text, -- The discovered Icinga Notifications socket path, if any.
 
   CONSTRAINT pk_icingadb_instance PRIMARY KEY (id)
 );

--- a/schema/pgsql/upgrades/notifications-health-and-discovery.sql
+++ b/schema/pgsql/upgrades/notifications-health-and-discovery.sql
@@ -1,0 +1,6 @@
+ALTER TABLE icingadb_instance
+  ADD COLUMN icingadb_service_user varchar(255) NOT NULL DEFAULT 'icingadb',
+  ADD COLUMN notifications_healthy boolenum DEFAULT NULL,
+  ADD COLUMN notifications_discovered_socket_path text;
+
+ALTER TABLE icingadb_instance ALTER COLUMN icingadb_service_user DROP DEFAULT;


### PR DESCRIPTION
This probes the Icinga Notifications listener socket availability once on startup and persists the result along with the Icinga DB service user to the `icingadb_instance` table. Also, when the Notifications component is indeed enabled, then it will monitor the Icinga Notifications API availability and persists the result into that very same table as well. If Icinga Notifications isn't available for some reason, then the current Icinga DB isntance will give up HA responsibilty after ~5m timeout, but if we don't have HA setup, then it will just retry the Icinga Notifications request endlessly and will never crash.

## TODO

- [x] Test it in HA setup (I've only tested this in a non-HA setup so far)
- [x] Agree on the newly introduced database column names (/cc @nilmerg)

## Testing

**Icinga DB 1:**

```bash
icingadb-1  | 2026-07-17T09:15:52.965+0200	INFO	high-availability	Another instance is active	{"instance_id": "c13c95aed1584ef49bd0df848c86c79c", "environment": "0162e462daea7c02249e1995a7fff030c776380f", "heartbeat": "2026-07-17T09:15:51.786+0200", "heartbeat_age": "1.179567057s"}
icingadb-1  | 2026-07-17T09:17:04.867+0200	INFO	icingadb	Taking over	{"reason": "no other instance is active"}
icingadb-1  | 2026-07-17T09:17:04.868+0200	INFO	icingadb	Starting config sync
icingadb-1  | 2026-07-17T09:17:04.868+0200	INFO	icingadb	Starting overdue sync
icingadb-1  | 2026-07-17T09:17:04.871+0200	INFO	icingadb	Starting initial state sync
icingadb-1  | 2026-07-17T09:17:05.054+0200	INFO	config-sync	Updating 2 items of type host state
icingadb-1  | 2026-07-17T09:17:05.082+0200	INFO	config-sync	Updating 24 items of type service state
icingadb-1  | 2026-07-17T09:17:05.757+0200	INFO	config-sync	Finished config sync in 889.91269ms
icingadb-1  | 2026-07-17T09:17:05.757+0200	INFO	icingadb	Starting config runtime updates sync
icingadb-1  | 2026-07-17T09:17:07.648+0200	INFO	notifications	Fetching 2 entities of type HostState from Redis for submission to Icinga Notifications
icingadb-1  | 2026-07-17T09:17:07.648+0200	INFO	notifications	Fetching 24 entities of type ServiceState from Redis for submission to Icinga Notifications
icingadb-1  | 2026-07-17T09:17:07.668+0200	INFO	icingadb	Starting state runtime updates sync
icingadb-1  | 2026-07-17T09:17:07.668+0200	INFO	icingadb	Starting history retention
icingadb-1  | 2026-07-17T09:17:07.668+0200	INFO	config-sync	Finished initial state sync in 2.800652177s
```

**Icinga DB 2:** It gave up HA responsibility after exactly 5 minutes the first time Icinga Notifications was identified as unhealthy.

```bash
icingadb-master2-1  | 2026-07-17T09:12:02.032+0200	ERROR	notifications	Cannot submit event to Icinga Notifications	{"event": "icinga-master2.devlab.com!disk /", "attempt": 1, "elapsed": "46.095872ms", "error": "cannot POST HTTP request to process event: cannot do HTTP request: Post \"http://notifications-master2:5680/process-event\": dial tcp: lookup notifications-master2 on 127.0.0.11:53: no such host", "errorVerbose": "Post \"http://notifications-master2:5680/process-event\": dial tcp: lookup notifications-master2 on 127.0.0.11:53: no such host\ncannot do HTTP request\ngithub.com/icinga/icinga-go-library/notifications/source.(*Client).doRequest\n\t/go/src/github.com/Icinga/icinga-go-library/notifications/source/client.go:340\ngithub.com/icinga/icinga-go-library/notifications/source.(*Client).ProcessEvent\n\t/go/src/github.com/Icinga/icinga-go-library/notifications/source/client.go:111\ngithub.com/icinga/icingadb/pkg/notifications.(*Client).Submit.func2\n\t/go/src/github.com/Icinga/icingadb/pkg/notifications/notifications.go:605\ngithub.com/icinga/icinga-go-library/retry.WithBackoff\n\t/go/src/github.com/Icinga/icinga-go-library/retry/retry.go:65\ngithub.com/icinga/icingadb/pkg/notifications.(*Client).Submit\n\t/go/src/github.com/Icinga/icingadb/pkg/notifications/notifications.go:593\ngithub.com/icinga/icingadb/pkg/icingadb.(*RuntimeUpdates).Sync.func2\n\t/go/src/github.com/Icinga/icingadb/pkg/icingadb/runtime_updates.go:216\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/go/pkg/mod/golang.org/x/sync@v0.22.0/errgroup/errgroup.go:93\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1447\ncannot POST HTTP request to process event\ngithub.com/icinga/icinga-go-library/notifications/source.(*Client).ProcessEvent\n\t/go/src/github.com/Icinga/icinga-go-library/notifications/source/client.go:124\ngithub.com/icinga/icingadb/pkg/notifications.(*Client).Submit.func2\n\t/go/src/github.com/Icinga/icingadb/pkg/notifications/notifications.go:605\ngithub.com/icinga/icinga-go-library/retry.WithBackoff\n\t/go/src/github.com/Icinga/icinga-go-library/retry/retry.go:65\ngithub.com/icinga/icingadb/pkg/notifications.(*Client).Submit\n\t/go/src/github.com/Icinga/icingadb/pkg/notifications/notifications.go:593\ngithub.com/icinga/icingadb/pkg/icingadb.(*RuntimeUpdates).Sync.func2\n\t/go/src/github.com/Icinga/icingadb/pkg/icingadb/runtime_updates.go:216\ngolang.org/x/sync/errgroup.(*Group).Go.func1\n\t/go/pkg/mod/golang.org/x/sync@v0.22.0/errgroup/errgroup.go:93\nruntime.goexit\n\t/usr/local/go/src/runtime/asm_arm64.s:1447"}
icingadb-master2-1  | 2026-07-17T09:12:12.783+0200	INFO	history-sync	Synced 10 state history items
icingadb-master2-1  | 2026-07-17T09:12:15.920+0200	INFO	runtime-updates	Upserted 7 ServiceState items
icingadb-master2-1  | 2026-07-17T09:12:32.783+0200	INFO	history-sync	Synced 2 state history items
icingadb-master2-1  | 2026-07-17T09:12:35.920+0200	INFO	runtime-updates	Upserted 3 ServiceState items
icingadb-master2-1  | 2026-07-17T09:12:52.783+0200	INFO	history-sync	Synced 1 state history items
icingadb-master2-1  | 2026-07-17T09:15:52.777+0200	INFO	high-availability	Continuing being the active instance	{"instance_id": "c13c95aed1584ef49bd0df848c86c79c", "environment": "0162e462daea7c02249e1995a7fff030c776380f"}
icingadb-master2-1  | 2026-07-17T09:17:04.670+0200	ERROR	high-availability	Icinga Notifications component has been unhealthy for a long time	{"unhealthy_since": "2026-07-17T09:12:02.032+0200"}
icingadb-master2-1  | 2026-07-17T09:17:04.672+0200	WARN	icingadb	Handing over	{"reason": "notifications component has been unhealthy for a long time"}
```

resolves #1141
refs https://github.com/Icinga/icingadb-web/issues/1356