### PR TITLE
Sync host & service check outputs to Notifications periodically

### DIFF
--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -374,6 +374,20 @@ func run() int {
 							return ret.Start(synctx)
 						})
 
+						if notificationsSource != nil {
+							g.Go(func() error {
+								stateInitSync.Wait()
+
+								if err := synctx.Err(); err != nil {
+									return err
+								}
+
+								logger.Info("Starting Icinga Notifications periodic outputs sync")
+
+								return notificationsSource.SyncCheckOutputs(synctx)
+							})
+						}
+
 						if err := g.Wait(); err != nil && !utils.IsContextCanceled(err) {
 							logger.Fatalf("%+v", err)
 						}

--- a/pkg/notifications/fetch.go
+++ b/pkg/notifications/fetch.go
@@ -11,6 +11,7 @@ import (
 	"github.com/icinga/icinga-go-library/backoff"
 	"github.com/icinga/icinga-go-library/com"
 	"github.com/icinga/icinga-go-library/database"
+	"github.com/icinga/icinga-go-library/redis"
 	"github.com/icinga/icinga-go-library/retry"
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/jmoiron/sqlx"
@@ -28,28 +29,21 @@ func panicForInvalidType(allowList []string, request string) {
 	}
 }
 
-// fetchObjectsFromRedis returns the objects with the requested ids of type typ from Redis.
-func (client *Client) fetchObjectsFromRedis(
-	ctx context.Context, typ string, ids ...types.Binary,
-) (map[string]*icingaObject, error) {
-	panicForInvalidType([]string{"host", "service"}, typ)
-
-	if len(ids) == 0 {
-		return nil, nil
-	}
-
-	key := "icinga:" + typ
-	strIds := make([]string, 0, len(ids))
-	for _, id := range ids {
-		strIds = append(strIds, id.String())
-	}
-
-	var out map[string]*icingaObject
-	err := retry.WithBackoff(
+// streamRedisHashObjects streams objects of type T from a Redis hash with the given key.
+//
+// This function is used to stream generic objects, such as hosts, host states, etc., from Redis.
+// The visitor function is called for each object, and can return an error to stop the streaming.
+func streamRedisHashObjects[T any](
+	ctx context.Context,
+	redisClient *redis.Client,
+	key string,
+	visitor func(*T, string) error,
+	ids ...string,
+) error {
+	return retry.WithBackoff(
 		ctx,
 		func(ctx context.Context) error {
-			out = make(map[string]*icingaObject)
-			pairCh, errCh := client.redisClient.HMYield(ctx, key, strIds...)
+			pairCh, errCh := redisClient.HMYield(ctx, key, ids...)
 
 			g, ctx := errgroup.WithContext(ctx)
 
@@ -65,15 +59,15 @@ func (client *Client) fetchObjectsFromRedis(
 							return nil
 						}
 
-						obj := new(icingaObject)
+						obj := new(T)
 						if err := json.Unmarshal([]byte(pair.Value), obj); err != nil {
 							return errors.Wrapf(err,
 								"cannot JSON unmarshal Redis HMGET result for %q with key %q",
 								key, pair.Field)
 						}
-						obj.isVolatile = obj.IsVolatile.Valid && obj.IsVolatile.Bool
-						obj.IsVolatile = types.Bool{} // Reset it, so that it is omitted from the JSON output.
-						out[pair.Field] = obj
+						if err := visitor(obj, pair.Field); err != nil {
+							return err
+						}
 					}
 				}
 			})
@@ -84,11 +78,34 @@ func (client *Client) fetchObjectsFromRedis(
 		backoff.DefaultBackoff,
 		retry.Settings{Timeout: retry.DefaultTimeout},
 	)
-	if err != nil {
-		return nil, errors.Wrapf(err, "cannot HMGET %q, %q from Redis", key, strIds)
+}
+
+// fetchObjectsFromRedis returns the objects with the requested ids of type typ from Redis.
+func (client *Client) fetchObjectsFromRedis(
+	ctx context.Context, typ string, ids ...types.Binary,
+) (map[string]*icingaObject, error) {
+	panicForInvalidType([]string{"host", "service"}, typ)
+
+	if len(ids) == 0 {
+		return nil, nil
 	}
 
-	return out, nil
+	strIds := make([]string, 0, len(ids))
+	for _, id := range ids {
+		strIds = append(strIds, id.String())
+	}
+
+	objects := make(map[string]*icingaObject)
+	err := streamRedisHashObjects(ctx, client.redisClient, "icinga:"+typ, func(obj *icingaObject, field string) error {
+		obj.isVolatile = obj.IsVolatile.Valid && obj.IsVolatile.Bool
+		obj.IsVolatile = types.Bool{} // Reset it, so that it is omitted from the JSON output.
+		objects[field] = obj
+		return nil
+	}, strIds...)
+	if err != nil {
+		return nil, err
+	}
+	return objects, nil
 }
 
 // fetchObjectFromRedis returns the single object with the requested id of type typ from Redis.

--- a/pkg/notifications/notifications.go
+++ b/pkg/notifications/notifications.go
@@ -8,6 +8,7 @@ import (
 	"maps"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -143,7 +144,17 @@ func (client *Client) ApplyDelta(ctx context.Context, delta *icingadb.Delta) err
 		return nil
 	}
 
-	client.fetchIncidents(ctx)
+	func() {
+		client.incidentsMu.Lock()
+		defer client.incidentsMu.Unlock()
+
+		// ApplyDelta is called in parallel for each entity type, so we need to ensure
+		// that we only fetch the incidents once per environment.
+		if client.incidentsByObjId != nil {
+			return
+		}
+		client.incidentsByObjId = client.retrieveEnvironmentIncidents(ctx)
+	}()
 	if len(client.incidentsByObjId) == 0 {
 		return nil
 	}
@@ -177,8 +188,8 @@ func (client *Client) ApplyDelta(ctx context.Context, delta *icingadb.Delta) err
 					if same, err := HaveSameState(incident, entity); err != nil {
 						return err
 					} else if same {
-						// Should we send a message update here too or just wait for the timer to expire
-						// and sync the message accordingly? See https://github.com/Icinga/icingadb/issues/1140
+						// Same state, but not necessarily the same output/message, and since we have a separate
+						// worker for syncing check outputs (see Client.SyncCheckOutputs), skip it entirely here.
 						continue
 					}
 				}
@@ -234,19 +245,124 @@ func (client *Client) ApplyDelta(ctx context.Context, delta *icingadb.Delta) err
 	return g.Wait()
 }
 
-// fetchIncidents fetches all incidents from the Icinga Notifications API and stores them in the Client's incidentsByObjId map.
+// SyncCheckOutputs periodically syncs the check outputs of all hosts and services to the Icinga Notifications API.
 //
-// If the incidents have already been fetched, this function does nothing. This function is safe to call concurrently.
-func (client *Client) fetchIncidents(ctx context.Context) {
-	client.incidentsMu.Lock()
-	defer client.incidentsMu.Unlock()
+// This function fetches the current incidents from the Icinga Notifications API, computes the corresponding
+// object IDs, retrieves all host and service states matching those IDs from Redis, and updates the check
+// outputs in Icinga Notifications if they have changed since the last sync.
+func (client *Client) SyncCheckOutputs(ctx context.Context) error {
+	lastSync := time.Now()
 
-	// ApplyDelta is called in parallel for each entity type, so we need to ensure
-	// that we only fetch the incidents once per environment.
-	if client.incidentsByObjId != nil {
-		return
+	// modify is a helper function to update the check output of a given state in Icinga Notifications.
+	modify := func(s *v1.State, idTags map[string]string) error {
+		if !s.Output.Valid || s.LastUpdate.Time().Before(lastSync) {
+			return nil // Skip state updates that haven't changed since the last sync, or that don't have a valid output.
+		}
+
+		var sb strings.Builder
+		sb.Grow(len(s.Output.String) + len(s.LongOutput.String) + 1)
+		sb.WriteString(s.Output.String)
+		if !s.LongOutput.IsZero() {
+			sb.WriteRune('\n')
+			sb.WriteString(s.LongOutput.String)
+		}
+
+		filter := make(map[string]any)
+		for k, v := range idTags {
+			filter[k] = v
+		}
+		if _, exists := idTags["service"]; !exists {
+			// Only match host incidents, not service incidents that have the same host name.
+			filter["service"] = nil
+		}
+
+		attrs := source.ModifiableIncidentAttrs{Message: types.MakeString(sb.String())}
+		return retry.WithBackoff(
+			ctx,
+			func(ctx context.Context) error { return client.notificationsClient.ModifyIncidents(ctx, attrs, filter) },
+			func(err error) bool { return true },
+			backoff.DefaultBackoff,
+			retry.Settings{
+				OnSuccess: func(elapsed time.Duration, attempt uint64, err error) {
+					client.sendHeartbeat(true)
+					if attempt > 1 {
+						client.logger.Debugw("Successfully updated incident status after retries",
+							zap.String("object_type", types.Name(s)),
+							zap.Duration("elapsed", elapsed),
+							zap.Uint64("attempt", attempt),
+							zap.String("error", err.Error()))
+					}
+				},
+				OnRetryableError: func(elapsed time.Duration, attempt uint64, err, lastErr error) {
+					client.sendHeartbeat(false)
+					if lastErr == nil || err.Error() != lastErr.Error() {
+						client.logger.Errorw("Failed to update incident status",
+							zap.String("object_type", types.Name(s)),
+							zap.Duration("elapsed", elapsed),
+							zap.Error(lastErr))
+					}
+				},
+			},
+		)
 	}
 
+	const interval = 5 * time.Minute
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case tick := <-ticker.C:
+			hostIncidents := make(map[string]source.Incident)
+			serviceIncidents := make(map[string]source.Incident)
+			for id, incident := range client.retrieveEnvironmentIncidents(ctx) {
+				if _, exists := incident.ObjectTags["service"]; exists {
+					serviceIncidents[id] = incident
+				} else {
+					hostIncidents[id] = incident
+				}
+			}
+
+			client.logger.Debugw("Syncing check outputs for incidents",
+				zap.Int("host_incidents", len(hostIncidents)),
+				zap.Int("service_incidents", len(serviceIncidents)),
+				zap.Time("last_sync", lastSync))
+
+			var wg sync.WaitGroup
+			if len(hostIncidents) > 0 {
+				wg.Go(func() {
+					_ = streamRedisHashObjects(ctx, client.redisClient, "icinga:host:state", func(hs *v1.HostState, _ string) error {
+						return modify(&hs.State, hostIncidents[hs.HostId.String()].ObjectTags)
+					}, slices.Collect(maps.Keys(hostIncidents))...)
+				})
+			}
+
+			if len(serviceIncidents) > 0 {
+				wg.Go(func() {
+					_ = streamRedisHashObjects(ctx, client.redisClient, "icinga:service:state", func(ss *v1.ServiceState, _ string) error {
+						return modify(&ss.State, serviceIncidents[ss.ServiceId.String()].ObjectTags)
+					}, slices.Collect(maps.Keys(serviceIncidents))...)
+				})
+			}
+			wg.Wait()
+
+			lastSync = tick
+			// In case the sync took a long time, the next tick might come immediately,
+			// so we reset the ticker to ensure a full interval between syncs.
+			ticker.Reset(interval)
+		}
+	}
+}
+
+// retrieveEnvironmentIncidents fetches all incidents for the current environment from the Icinga Notifications API.
+//
+// The incidents are returned as a map of object IDs to incidents. The object IDs are generated based on the
+// environment ID and the host/service names, mimicking the Icinga 2 ID generation behavior used to generate
+// all Icinga DB related object IDs.
+func (client *Client) retrieveEnvironmentIncidents(ctx context.Context) map[string]source.Incident {
 	environment, ok := v1.EnvironmentFromContext(ctx)
 	if !ok {
 		panic("cannot get environment from context")
@@ -254,7 +370,7 @@ func (client *Client) fetchIncidents(ctx context.Context) {
 
 	incidentsCh, errCh := client.notificationsClient.YieldIncidents(ctx, map[string]string{"environment": environment.ID().String()})
 
-	client.incidentsByObjId = make(map[string]source.Incident)
+	incidentsByID := make(map[string]source.Incident)
 	hash := sha1.New() // #nosec G401 -- used as a non-cryptographic hash function to hash IDs
 	for incident := range incidentsCh {
 		// This implementation mimics the Icinga 2 ID generation behavior[^1] used to generate all Icinga DB
@@ -273,7 +389,7 @@ func (client *Client) fetchIncidents(ctx context.Context) {
 				zap.Error(err))
 			continue
 		}
-		client.incidentsByObjId[hex.EncodeToString(hash.Sum(nil))] = incident
+		incidentsByID[hex.EncodeToString(hash.Sum(nil))] = incident
 		hash.Reset()
 	}
 
@@ -281,6 +397,7 @@ func (client *Client) fetchIncidents(ctx context.Context) {
 		client.sendHeartbeat(false)
 		client.logger.Errorw("Failed to fetch incidents", zap.String("error", err.Error()))
 	}
+	return incidentsByID
 }
 
 // sendHeartbeat sends a heartbeat signal to the HA controller via the heartbeatOutCh channel.


### PR DESCRIPTION
In order to always have the latest check output of a checkable, there is now a new goroutine that periodically (every 5 minutes) syncs the check output of all checkables that have an active incident state from the `icinga:{host,service}:state` Redis hashes to Icinga Notifications. This is necessary because a checkable's check can, for instance, be in `CRITICAL` state for a long time, while its output can change with each check result. And since that won't trigger any state change events, thus, not queued to the runtime updates stream, there's no way for Icinga Notifications to know about the updated output.

```bash
icingadb-1  | 2026-07-21T13:08:45.586+0200	DEBUG	notifications	Syncing check outputs for incidents	{"host_incidents": 0, "service_incidents": 10, "last_sync": "2026-07-21T13:03:45.586+0200"}
icingadb-1  | 2026-07-21T13:13:45.650+0200	DEBUG	notifications	Syncing check outputs for incidents {"host_incidents": 0, "service_incidents": 10, "last_sync": "2026-07-21T13:08:45.645+0200"}
icingadb-1  | 2026-07-21T13:18:45.719+0200	DEBUG	notifications	Syncing check outputs for incidents {"host_incidents": 0, "service_incidents": 10, "last_sync": "2026-07-21T13:13:45.718+0200"}
icingadb-1  | 2026-07-21T13:23:45.792+0200	DEBUG	notifications	Syncing check outputs for incidents	{"host_incidents": 0, "service_incidents": 10, "last_sync": "2026-07-21T13:18:45.792+0200"}
icingadb-1  | 2026-07-21T13:28:45.869+0200	DEBUG	notifications	Syncing check outputs for incidents	{"host_incidents": 0, "service_incidents": 10, "last_sync": "2026-07-21T13:23:45.869+0200"}
```

resolves #1140