### PR TITLE
Notifications: Load Configuration from Database

### DIFF
--- a/.github/workflows/sql.yml
+++ b/.github/workflows/sql.yml
@@ -16,12 +16,8 @@ jobs:
       fail-fast: false
       matrix:
         database:
-          - {type: MYSQL, name: MySQL 5.5,         image: "icinga/icingadb-mysql:5.5"}
-          - {type: MYSQL, name: MySQL 5.6,         image: "icinga/icingadb-mysql:5.6"}
-          - {type: MYSQL, name: MySQL 5.7,         image: "mysql:5.7"}
           - {type: MYSQL, name: MySQL 8,           image: "mysql:8"}
           - {type: MYSQL, name: MySQL latest,      image: "mysql:latest"}
-          - {type: MYSQL, name: MariaDB 10.1,      image: "mariadb:10.1"}
           - {type: MYSQL, name: MariaDB 10.2,      image: "mariadb:10.2"}
           - {type: MYSQL, name: MariaDB 10.3,      image: "mariadb:10.3"}
           - {type: MYSQL, name: MariaDB 10.4,      image: "mariadb:10.4"}

--- a/cmd/icingadb/main.go
+++ b/cmd/icingadb/main.go
@@ -137,7 +137,12 @@ func run() int {
 		}
 		defer func() { _ = db.Close() }()
 		db.SetMaxOpenConns(1)
-		ha = icingadb.NewHA(ctx, db, heartbeat, logs.GetChildLogger("high-availability"))
+		ha = icingadb.NewHA(
+			ctx,
+			db,
+			heartbeat,
+			logs.GetChildLogger("high-availability"),
+			cmd.Config.Notifications.SynchronizeWithDatabase)
 
 		telemetryLogger := logs.GetChildLogger("telemetry")
 		telemetrySyncStats = telemetry.StartHeartbeat(ctx, rc, telemetryLogger, ha, heartbeat)
@@ -170,18 +175,23 @@ func run() int {
 	signal.Notify(sig, os.Interrupt, syscall.SIGTERM, syscall.SIGHUP)
 
 	var notificationsSource *notifications.Client
-	if cfg := cmd.Config.Notifications; cfg.Url != "" {
-		logger.Info("Starting Icinga Notifications source")
-
+	if cfg := cmd.Config.Notifications; cfg.SynchronizeWithDatabase || cfg.Url != "" {
 		notificationsSource, err = notifications.NewNotificationsClient(
 			db,
 			rc,
 			logs.GetChildLogger("notifications"),
 			cfg,
-			ha.NotificationsHeartbeat())
+			ha)
 		if err != nil {
 			logger.Fatalw("Can't create Icinga Notifications client from config", zap.Error(err))
 		}
+
+		go func() {
+			err := notificationsSource.PersistLockedConfigOnce(ctx)
+			if err != nil && !utils.IsContextCanceled(err) {
+				logger.Fatalf("%+v", err)
+			}
+		}()
 	}
 
 	go func() {
@@ -207,6 +217,15 @@ func run() int {
 			case takeoverReason := <-ha.Takeover():
 				logger.WithOptions(logs.ForceLog()).Infow("Taking over", zap.String("reason", takeoverReason))
 
+				if notificationsSource != nil {
+					go func() {
+						err := notificationsSource.SynchronizeConfigWithDatabase(hactx)
+						if err != nil && !utils.IsContextCanceled(err) {
+							logger.Fatalf("%+v", err)
+						}
+					}()
+				}
+
 				go func() {
 					for hactx.Err() == nil {
 						synctx, cancelSynctx := context.WithCancel(ha.Environment().NewContext(hactx))
@@ -215,6 +234,10 @@ func run() int {
 						// Runtime updates must wait for initial synchronization to complete.
 						configInitSync := sync.WaitGroup{}
 						stateInitSync := &sync.WaitGroup{}
+
+						// Decided once per sync round, so that everything within agrees on whether Icinga Notifications
+						// is available. Any later change of the Client cancels synctx and starts a new round.
+						notificationsConfigured := notificationsSource != nil && notificationsSource.IsConfigured()
 
 						// Clear the runtime update streams before starting anything else (rather than after the sync),
 						// otherwise updates may be lost.
@@ -231,11 +254,19 @@ func run() int {
 						})
 
 						g.Go(func() error {
+							var notificationsReconfiguredCh <-chan struct{}
+							if notificationsSource != nil {
+								notificationsReconfiguredCh = notificationsSource.ReconfiguredCh()
+							}
+
 							select {
 							case <-dump.InProgress():
 								logger.Info("Icinga 2 started a new config dump, waiting for it to complete")
 								cancelSynctx()
-
+								return nil
+							case <-notificationsReconfiguredCh:
+								logger.Info("Icinga Notifications component has been reconfigured, restarting sync")
+								cancelSynctx()
 								return nil
 							case <-synctx.Done():
 								return synctx.Err()
@@ -270,7 +301,7 @@ func run() int {
 								defer stateInitSync.Done()
 
 								var hook icingadb.DeltaHook
-								if notificationsSource != nil {
+								if notificationsConfigured {
 									hook = notificationsSource.ApplyDelta
 									defer func() {
 										if stateSyncWorkers.Add(-1) == 0 {
@@ -353,7 +384,7 @@ func run() int {
 							logger.Info("Starting state runtime updates sync")
 
 							runtimeUpdatesOpts := []icingadb.RUOption{icingadb.WithAllowParallel()}
-							if notificationsSource != nil {
+							if notificationsConfigured {
 								runtimeUpdatesOpts = append(runtimeUpdatesOpts, icingadb.WithRUUpsert(notificationsSource.Submit))
 							}
 
@@ -374,7 +405,7 @@ func run() int {
 							return ret.Start(synctx)
 						})
 
-						if notificationsSource != nil {
+						if notificationsConfigured {
 							g.Go(func() error {
 								stateInitSync.Wait()
 

--- a/config.example.yml
+++ b/config.example.yml
@@ -152,7 +152,7 @@ redis:
 	#   For example: https://example.com:5680
 	# - unix: HTTP connection over a Unix Domain Socket. Authentication is based on the operating system user.
 	#   For example: unix:///path/to/socket
-#  url: http://localhost:5680
+#  url:
 
   # Base URL of the Icinga Web 2 setup in front of this Icinga DB. It is used to build the absolute object URLs
   # transmitted with each event, which Icinga Notifications passes on to the notified contacts. This must be an
@@ -160,10 +160,10 @@ redis:
 #  icingaweb2_url: https://example.com/icingaweb2
 
   # Username to authenticate against the Icinga Notifications API.
-#  username: icingadb
+#  username:
 
   # Password for the defined user.
-#  password: insecureinsecure
+#  password:
 #  password_file: /run/secerets/icingadb_notifications_password
 
   # TLS configuration for https URLs. The ca is used to verify the server cert, while cert and key are the client certificate.
@@ -171,7 +171,10 @@ redis:
 #  cert: /path/to/client.crt
 #  key: /path/to/client.key
 
-  # Relations as a JSONPath to resolve and include in the events submitted to Icinga Notifications.
+  # Relations as an array of JSONPath to resolve and include in the events submitted to Icinga Notifications.
+  # For example '$.host.vars' and '$.services[*].vars'.
 #  default_relations:
-#    - '$.host.vars'
-#    - '$.services[*].vars'
+
+  # Synchronize the configuration with the database. This allows Icinga Notifications Web to configure this source.
+  # If set, all other fields can be left empty. However, if set, they take precedence.
+#  synchronize_with_database: true

--- a/doc/03-Configuration.md
+++ b/doc/03-Configuration.md
@@ -205,6 +205,11 @@ Different URI schemes are possible for the configured URL, depending on how Icin
 * `https`: HTTPS connection. Either `username` and `password`/`password_file` or `cert` and `key` are required. For example: `https://example.com:5680`
 * `unix`: HTTP connection over a Unix Domain Socket. Authentication is based on the operating system user. For example: `unix:///path/to/socket`
 
+Icinga DB synchronizes the Icinga Notifications configuration with the database.
+This allows Icinga Notifications Web to configure this source.
+Any option set in either the YAML or environment variable configuration takes precedence over everything which might be configured in the database.
+To disable a database-bound configuration, set `synchronize_with_database` to `false`.
+
 Each event is submitted with a URL pointing at the affected host or service in Icinga Web 2, which Icinga Notifications
 passes on to the notified contacts. Since Icinga Notifications does not know where your Icinga Web 2 lives, this URL has
 to be absolute, which is what `icingaweb2_url` is for. Leaving it empty is allowed and results in events without an
@@ -213,18 +218,19 @@ object URL, so the notified contacts get no link to follow.
 For YAML configuration, the options are part of the `notifications` dictionary.
 For environment variables, each option is prefixed with `ICINGADB_NOTIFICATIONS_`.
 
-| Option            | Description                                                                                                           |
-|-------------------|-----------------------------------------------------------------------------------------------------------------------|
-| url               | **Optional.** Icinga Notifications API base URL.                                                                      |
-| icingaweb2_url    | **Optional.** Base URL of your Icinga Web 2, e.g. `https://example.com/icingaweb2`. Must be absolute.                 |
-| username          | **Optional.** Icinga Notifications API user for this source.                                                          |
-| password          | **Optional.** Icinga Notifications API user password.                                                                 |
-| password_file     | **Optional.** Icinga Notifications API user password file.                                                            |
-| cert              | **Optional.** TLS client certificate, either file path or PEM-encoded multiline string.                               |
-| key               | **Optional.** TLS client private key, either file path or PEM-encoded multiline string.                               |
-| ca                | **Optional.** TLS CA certificate, either file path or PEM-encoded multiline string.                                   |
-| insecure          | **Optional.** Whether not to verify the peer.                                                                         |
-| default_relations | **Optional.** List of relations as a JSONPath to resolve and include in the events submitted to Icinga Notifications. |
+| Option                    | Description                                                                                                           |
+|---------------------------|-----------------------------------------------------------------------------------------------------------------------|
+| url                       | **Optional.** Icinga Notifications API base URL.                                                                      |
+| username                  | **Optional.** Icinga Notifications API user for this source.                                                          |
+| password                  | **Optional.** Icinga Notifications API user password.                                                                 |
+| password_file             | **Optional.** Icinga Notifications API user password file.                                                            |
+| cert                      | **Optional.** TLS client certificate, either file path or PEM-encoded multiline string.                               |
+| key                       | **Optional.** TLS client private key, either file path or PEM-encoded multiline string.                               |
+| ca                        | **Optional.** TLS CA certificate, either file path or PEM-encoded multiline string.                                   |
+| insecure                  | **Optional.** Whether not to verify the peer.                                                                         |
+| default_relations         | **Optional.** List of relations as a JSONPath to resolve and include in the events submitted to Icinga Notifications. |
+| icingaweb2_url            | **Optional.** Base URL of your Icinga Web 2, e.g. `https://example.com/icingaweb2`. Must be absolute.                 |
+| synchronize_with_database | **Optional.** Synchronize complete Notifications Configuration with the database. Enabled by default.                 |
 
 ## Appendix
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/icinga/icingadb
 go 1.25.0
 
 require (
+	github.com/caarlos0/env/v11 v11.4.1
 	github.com/creasty/defaults v1.8.0
 	github.com/goccy/go-yaml v1.13.0
 	github.com/google/go-cmp v0.7.0
@@ -25,7 +26,6 @@ require (
 	filippo.io/edwards25519 v1.2.0 // indirect
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
-	github.com/caarlos0/env/v11 v11.4.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/fatih/color v1.18.0 // indirect
 	github.com/fsnotify/fsnotify v1.10.1 // indirect

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"github.com/creasty/defaults"
 	"github.com/icinga/icinga-go-library/database"
 	"github.com/icinga/icinga-go-library/logging"
@@ -9,6 +10,9 @@ import (
 	"github.com/icinga/icingadb/pkg/icingadb/history"
 	"github.com/pkg/errors"
 	"github.com/theory/jsonpath"
+	"reflect"
+	"slices"
+	"strings"
 	"time"
 )
 
@@ -17,11 +21,11 @@ const DefaultConfigPath = "/etc/icingadb/config.yml"
 
 // Config defines Icinga DB config.
 type Config struct {
-	Database      database.Config `yaml:"database" envPrefix:"DATABASE_"`
-	Redis         redis.Config    `yaml:"redis" envPrefix:"REDIS_"`
-	Logging       logging.Config  `yaml:"logging" envPrefix:"LOGGING_"`
-	Retention     RetentionConfig `yaml:"retention" envPrefix:"RETENTION_"`
-	Notifications source.Config   `yaml:"notifications" envPrefix:"NOTIFICATIONS_"`
+	Database      database.Config     `yaml:"database" envPrefix:"DATABASE_"`
+	Redis         redis.Config        `yaml:"redis" envPrefix:"REDIS_"`
+	Logging       logging.Config      `yaml:"logging" envPrefix:"LOGGING_"`
+	Retention     RetentionConfig     `yaml:"retention" envPrefix:"RETENTION_"`
+	Notifications NotificationsConfig `yaml:"notifications" envPrefix:"NOTIFICATIONS_"`
 }
 
 func (c *Config) SetDefaults() {
@@ -123,4 +127,65 @@ func (r *RetentionConfig) Validate() error {
 	}
 
 	return r.Options.Validate()
+}
+
+// NotificationsConfig wraps source.Config for autoconfiguration and env-like serialization.
+//
+// When NotificationsConfig.SynchronizeWithDatabase is set, everything is sourced from the database.
+type NotificationsConfig struct {
+	source.Config `yaml:",inline"`
+
+	SynchronizeWithDatabase bool `yaml:"synchronize_with_database" env:"SYNCHRONIZE_WITH_DATABASE" default:"true"`
+}
+
+// StaticConfig emits all set/changed/non-default configuration values with a key mimicking the env key.
+//
+// Pairs carrying sensitive information, such as passwords or private keys, are stored with a redacted value.
+func (c NotificationsConfig) StaticConfig() map[string]string {
+	out := make(map[string]string)
+	activeEncConfig(reflect.ValueOf(c.Config), "ICINGADB_NOTIFICATIONS_", out)
+	return out
+}
+
+// activeEncConfig emits all set config values into a map with a key mimicking the env key.
+//
+// This function is used in NotificationsConfig.StaticConfig and currently only implements what is required there.
+//
+// Fields with the "unset" env tag option are considered sensitive. Their value will be REDACTED.
+func activeEncConfig(v reflect.Value, prefix string, out map[string]string) {
+	t := v.Type()
+	for i := range t.NumField() {
+		fieldT := t.Field(i)
+		fieldV := v.Field(i)
+
+		if !fieldT.IsExported() {
+			continue
+		}
+
+		if fieldV.Kind() == reflect.Struct {
+			activeEncConfig(fieldV, prefix+fieldT.Tag.Get("envPrefix"), out)
+			continue
+		}
+
+		name, opts, _ := strings.Cut(fieldT.Tag.Get("env"), ",")
+		if name == "" || name == "-" {
+			continue
+		}
+
+		if defaults.CanUpdate(fieldV.Interface()) {
+			continue
+		}
+
+		if slices.Contains(strings.Split(opts, ","), "unset") {
+			out[prefix+name] = "REDACTED"
+		} else if fieldV.Kind() == reflect.Slice {
+			parts := make([]string, fieldV.Len())
+			for i := range parts {
+				parts[i] = fmt.Sprintf("%v", fieldV.Index(i).Interface())
+			}
+			out[prefix+name] = strings.Join(parts, ",")
+		} else {
+			out[prefix+name] = fmt.Sprintf("%v", fieldV.Interface())
+		}
+	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,10 +1,12 @@
 package config
 
 import (
+	"github.com/caarlos0/env/v11"
 	"github.com/creasty/defaults"
 	"github.com/icinga/icinga-go-library/config"
 	"github.com/icinga/icinga-go-library/database"
 	"github.com/icinga/icinga-go-library/logging"
+	"github.com/icinga/icinga-go-library/notifications/source"
 	"github.com/icinga/icinga-go-library/redis"
 	"github.com/icinga/icinga-go-library/testutils"
 	"github.com/icinga/icingadb/pkg/icingadb/history"
@@ -183,6 +185,36 @@ retention:
 			},
 		},
 		{
+			Name: "Custom Notifications Config from YAML",
+			Data: testutils.ConfigTestData{
+				Yaml: yamlConfig + `
+notifications:
+  url: http://example.com/
+  username: icingadb
+  password: insecure
+`,
+			},
+			Expected: &Config{
+				Database: database.Config{
+					Host:     "192.0.2.1",
+					Database: "icingadb",
+					User:     "icingadb",
+					Password: "icingadb",
+				},
+				Redis: redis.Config{
+					Host: "2001:db8::1",
+				},
+				Notifications: NotificationsConfig{
+					Config: source.Config{
+						Url:      "http://example.com/",
+						Username: "icingadb",
+						Password: "insecure",
+					},
+					SynchronizeWithDatabase: true,
+				},
+			},
+		},
+		{
 			Name: "Unknown YAML field",
 			Data: testutils.ConfigTestData{
 				Yaml: `unknown: unknown`,
@@ -218,4 +250,30 @@ retention:
 			return actual, err
 		}))
 	}
+}
+
+func TestNotificationsConfig_StaticConfig(t *testing.T) {
+	cfg := NotificationsConfig{
+		Config: source.Config{
+			Url:              "https://example.com:5680",
+			Username:         "icingadb",
+			Password:         "icingadb",
+			TlsOptions:       config.TLS{Insecure: true},
+			DefaultRelations: []string{"$.foo", "$.bar"},
+		},
+	}
+
+	staticConf := cfg.StaticConfig()
+	require.Equal(t, map[string]string{
+		"ICINGADB_NOTIFICATIONS_URL":               "https://example.com:5680",
+		"ICINGADB_NOTIFICATIONS_USERNAME":          "icingadb",
+		"ICINGADB_NOTIFICATIONS_PASSWORD":          "REDACTED",
+		"ICINGADB_NOTIFICATIONS_INSECURE":          "true",
+		"ICINGADB_NOTIFICATIONS_DEFAULT_RELATIONS": "$.foo,$.bar",
+	}, staticConf)
+
+	var cmpCfg Config
+	require.NoError(t, env.ParseWithOptions(&cmpCfg, env.Options{Prefix: "ICINGADB_", Environment: staticConf}))
+	cmpCfg.Notifications.Config.Password = "icingadb" // Reset, as redacted in output
+	require.Equal(t, cfg, cmpCfg.Notifications)
 }

--- a/pkg/icingadb/ha.go
+++ b/pkg/icingadb/ha.go
@@ -59,33 +59,41 @@ func (ns *NotificationsState) IsValidUnhealthy() bool {
 
 // HA provides high availability and indicates whether a Takeover or Handover must be made.
 type HA struct {
-	state         atomic.Pointer[haState]
-	ctx           context.Context
-	cancelCtx     context.CancelFunc
-	instanceId    types.Binary
-	db            *database.DB
-	environmentMu sync.Mutex
-	environment   *v1.Environment
-	heartbeat     *icingaredis.Heartbeat
-	logger        *logging.Logger
-	responsible   bool
-	handover      chan string
-	takeover      chan string
-	done          chan struct{}
-	errOnce       sync.Once
-	errMu         sync.Mutex
-	err           error
+	state       atomic.Pointer[haState]
+	ctx         context.Context
+	cancelCtx   context.CancelFunc
+	instanceId  types.Binary
+	db          *database.DB
+	environment *v1.Environment
+	endpointId  types.Binary
+	heartbeat   *icingaredis.Heartbeat
+	logger      *logging.Logger
+	responsible bool
+	handover    chan string
+	takeover    chan string
+	done        chan struct{}
+	errOnce     sync.Once
+	err         error
+	mu          sync.Mutex // protects environment, endpointId, and err
 
 	// notificationsHeartbeat is a channel that signals the status of the Icinga Notifications component.
 	//
 	// This will only receive events when the Icinga Notifications component is enabled, and its true value indicates
 	// that the component is healthy and able to process notifications, while a false value indicates that it is not.
-	notificationsHeartbeatCh chan bool
-	notifications            NotificationsState
+	// An invalid types.Bool resets the state to unknown, e.g., after the component was stopped again.
+	notificationsHeartbeatCh             chan types.Bool
+	notifications                        NotificationsState
+	notificationsSynchronizeWithDatabase types.Bool
 }
 
 // NewHA returns a new HA and starts the controller loop.
-func NewHA(ctx context.Context, db *database.DB, heartbeat *icingaredis.Heartbeat, logger *logging.Logger) *HA {
+func NewHA(
+	ctx context.Context,
+	db *database.DB,
+	heartbeat *icingaredis.Heartbeat,
+	logger *logging.Logger,
+	notificationsSynchronizeWithDatabase bool,
+) *HA {
 	ctx, cancelCtx := context.WithCancel(ctx)
 
 	instanceId := uuid.New()
@@ -101,7 +109,8 @@ func NewHA(ctx context.Context, db *database.DB, heartbeat *icingaredis.Heartbea
 		takeover:   make(chan string),
 		done:       make(chan struct{}),
 
-		notificationsHeartbeatCh: make(chan bool),
+		notificationsHeartbeatCh:             make(chan types.Bool),
+		notificationsSynchronizeWithDatabase: types.MakeBool(notificationsSynchronizeWithDatabase),
 	}
 
 	ha.state.Store(&haState{})
@@ -130,16 +139,24 @@ func (h *HA) Done() <-chan struct{} {
 
 // Environment returns the current environment.
 func (h *HA) Environment() *v1.Environment {
-	h.environmentMu.Lock()
-	defer h.environmentMu.Unlock()
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
 	return h.environment
 }
 
+// EndpointID returns the current endpoint ID.
+func (h *HA) EndpointID() types.Binary {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return h.endpointId
+}
+
 // Err returns an error if Done has been closed and there is an error. Otherwise returns nil.
 func (h *HA) Err() error {
-	h.errMu.Lock()
-	defer h.errMu.Unlock()
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
 	return h.err
 }
@@ -158,7 +175,8 @@ func (h *HA) Takeover() chan string {
 //
 // The channel is used to signal the health of the Icinga Notifications component, where a true value indicates
 // that the component is healthy and able to process notifications, while a false value indicates that it is not.
-func (h *HA) NotificationsHeartbeat() chan<- bool { return h.notificationsHeartbeatCh }
+// An invalid types.Bool marks the state as unknown, as it is before the component has been configured.
+func (h *HA) NotificationsHeartbeat() chan<- types.Bool { return h.notificationsHeartbeatCh }
 
 // State returns the status quo.
 func (h *HA) State() (responsibleTsMilli int64, responsible, otherResponsible bool) {
@@ -169,9 +187,9 @@ func (h *HA) State() (responsibleTsMilli int64, responsible, otherResponsible bo
 
 func (h *HA) abort(err error) {
 	h.errOnce.Do(func() {
-		h.errMu.Lock()
+		h.mu.Lock()
 		h.err = errors.Wrap(err, "HA aborted")
-		h.errMu.Unlock()
+		h.mu.Unlock()
 
 		h.cancelCtx()
 	})
@@ -222,6 +240,17 @@ func (h *HA) controller() {
 					h.abort(err)
 				}
 
+				h.mu.Lock()
+				if !bytes.Equal(h.endpointId, s.EndpointId) {
+					if h.endpointId.Valid() {
+						h.logger.Warnw("Endpoint ID changed unexpectedly",
+							zap.String("current", h.endpointId.String()),
+							zap.String("new", s.EndpointId.String()))
+					}
+					h.endpointId = s.EndpointId
+				}
+				h.mu.Unlock()
+
 				envId, err := m.EnvironmentID()
 				if err != nil {
 					h.abort(err)
@@ -234,14 +263,14 @@ func (h *HA) controller() {
 							zap.String("new", envId.String()))
 					}
 
-					h.environmentMu.Lock()
+					h.mu.Lock()
 					h.environment = &v1.Environment{
 						EntityWithoutChecksum: v1.EntityWithoutChecksum{IdMeta: v1.IdMeta{
 							Id: envId,
 						}},
 						Name: types.MakeString(envId.String()),
 					}
-					h.environmentMu.Unlock()
+					h.mu.Unlock()
 				}
 
 				select {
@@ -283,9 +312,9 @@ func (h *HA) controller() {
 			}
 
 		case healthy := <-h.notificationsHeartbeatCh:
-			h.logger.Debugw("Received notifications heartbeat", zap.Bool("healthy", healthy))
-			h.notifications.healthy = types.MakeBool(healthy)
-			if healthy {
+			h.logger.Debugw("Received notifications heartbeat", zap.Any("healthy", healthy))
+			h.notifications.healthy = healthy
+			if !healthy.Valid || healthy.Bool {
 				h.notifications.unhealthySince = time.Time{}
 			} else if h.notifications.unhealthySince.IsZero() {
 				h.notifications.unhealthySince = time.Now()
@@ -407,21 +436,22 @@ func (h *HA) realize(
 				EnvironmentMeta: v1.EnvironmentMeta{
 					EnvironmentId: envId,
 				},
-				Heartbeat:                         types.UnixMilli(time.UnixMilli(h.heartbeat.LastMessageTime())),
-				Responsible:                       types.Bool{Bool: takeover != "" || h.responsible, Valid: true},
-				EndpointId:                        s.EndpointId,
-				Icinga2Version:                    s.Version,
-				Icinga2StartTime:                  s.ProgramStart,
-				Icinga2NotificationsEnabled:       s.NotificationsEnabled,
-				Icinga2ActiveServiceChecksEnabled: s.ActiveServiceChecksEnabled,
-				Icinga2ActiveHostChecksEnabled:    s.ActiveHostChecksEnabled,
-				Icinga2EventHandlersEnabled:       s.EventHandlersEnabled,
-				Icinga2FlapDetectionEnabled:       s.FlapDetectionEnabled,
-				Icinga2PerformanceDataEnabled:     s.PerformanceDataEnabled,
-				IcingadbVersion:                   internal.Version.Version,
-				IcingadbServiceUser:               ServiceUser(),
-				NotificationsHealthy:              h.notifications.healthy,
-				NotificationsDiscoveredSocketPath: h.probeNotificationsSocketPath(),
+				Heartbeat:                            types.UnixMilli(time.UnixMilli(h.heartbeat.LastMessageTime())),
+				Responsible:                          types.Bool{Bool: takeover != "" || h.responsible, Valid: true},
+				EndpointId:                           s.EndpointId,
+				Icinga2Version:                       s.Version,
+				Icinga2StartTime:                     s.ProgramStart,
+				Icinga2NotificationsEnabled:          s.NotificationsEnabled,
+				Icinga2ActiveServiceChecksEnabled:    s.ActiveServiceChecksEnabled,
+				Icinga2ActiveHostChecksEnabled:       s.ActiveHostChecksEnabled,
+				Icinga2EventHandlersEnabled:          s.EventHandlersEnabled,
+				Icinga2FlapDetectionEnabled:          s.FlapDetectionEnabled,
+				Icinga2PerformanceDataEnabled:        s.PerformanceDataEnabled,
+				IcingadbVersion:                      internal.Version.Version,
+				IcingadbServiceUser:                  ServiceUser(),
+				NotificationsHealthy:                 h.notifications.healthy,
+				NotificationsDiscoveredSocketPath:    h.probeNotificationsSocketPath(),
+				NotificationsSynchronizeWithDatabase: h.notificationsSynchronizeWithDatabase,
 			}
 
 			stmt, _ := h.db.BuildUpsertStmt(i)

--- a/pkg/icingadb/v1/icingadb_config.go
+++ b/pkg/icingadb/v1/icingadb_config.go
@@ -1,0 +1,19 @@
+package v1
+
+import (
+	"github.com/icinga/icinga-go-library/types"
+)
+
+// IcingadbConfig contains configuration in the environment key/value format, currently only used for Notifications.
+type IcingadbConfig struct {
+	EnvironmentMeta `json:",inline"`
+	EndpointId      types.Binary `json:"endpoint_id"`
+	EnvKey          string       `json:"env_key"`
+	EnvValue        string       `json:"env_value"`
+	Locked          types.Bool   `json:"locked"`
+}
+
+// UnconfiguredEndpointId returns an IcingadbConfig.EndpointId for endpoint-unspecific settings.
+func UnconfiguredEndpointId() types.Binary {
+	return make(types.Binary, 20)
+}

--- a/pkg/icingadb/v1/icingadb_instance.go
+++ b/pkg/icingadb/v1/icingadb_instance.go
@@ -5,21 +5,22 @@ import (
 )
 
 type IcingadbInstance struct {
-	EntityWithoutChecksum             `json:",inline"`
-	EnvironmentMeta                   `json:",inline"`
-	EndpointId                        types.Binary    `json:"endpoint_id"`
-	Heartbeat                         types.UnixMilli `json:"heartbeat"`
-	Responsible                       types.Bool      `json:"responsible"`
-	Icinga2Version                    string          `json:"icinga2_version"`
-	Icinga2StartTime                  types.UnixMilli `json:"icinga2_start_time"`
-	Icinga2NotificationsEnabled       types.Bool      `json:"icinga2_notifications_enabled"`
-	Icinga2ActiveServiceChecksEnabled types.Bool      `json:"icinga2_active_service_checks_enabled"`
-	Icinga2ActiveHostChecksEnabled    types.Bool      `json:"icinga2_active_host_checks_enabled"`
-	Icinga2EventHandlersEnabled       types.Bool      `json:"icinga2_event_handlers_enabled"`
-	Icinga2FlapDetectionEnabled       types.Bool      `json:"icinga2_flap_detection_enabled"`
-	Icinga2PerformanceDataEnabled     types.Bool      `json:"icinga2_performance_data_enabled"`
-	IcingadbVersion                   string          `json:"-"`
-	IcingadbServiceUser               string          `json:"-"`
-	NotificationsHealthy              types.Bool      `json:"-"`
-	NotificationsDiscoveredSocketPath types.String    `json:"-"`
+	EntityWithoutChecksum                `json:",inline"`
+	EnvironmentMeta                      `json:",inline"`
+	EndpointId                           types.Binary    `json:"endpoint_id"`
+	Heartbeat                            types.UnixMilli `json:"heartbeat"`
+	Responsible                          types.Bool      `json:"responsible"`
+	Icinga2Version                       string          `json:"icinga2_version"`
+	Icinga2StartTime                     types.UnixMilli `json:"icinga2_start_time"`
+	Icinga2NotificationsEnabled          types.Bool      `json:"icinga2_notifications_enabled"`
+	Icinga2ActiveServiceChecksEnabled    types.Bool      `json:"icinga2_active_service_checks_enabled"`
+	Icinga2ActiveHostChecksEnabled       types.Bool      `json:"icinga2_active_host_checks_enabled"`
+	Icinga2EventHandlersEnabled          types.Bool      `json:"icinga2_event_handlers_enabled"`
+	Icinga2FlapDetectionEnabled          types.Bool      `json:"icinga2_flap_detection_enabled"`
+	Icinga2PerformanceDataEnabled        types.Bool      `json:"icinga2_performance_data_enabled"`
+	IcingadbVersion                      string          `json:"-"`
+	IcingadbServiceUser                  string          `json:"-"`
+	NotificationsHealthy                 types.Bool      `json:"-"`
+	NotificationsDiscoveredSocketPath    types.String    `json:"-"`
+	NotificationsSynchronizeWithDatabase types.Bool      `json:"-"`
 }

--- a/pkg/notifications/notifications.go
+++ b/pkg/notifications/notifications.go
@@ -10,8 +10,10 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
+	"github.com/caarlos0/env/v11"
 	"github.com/icinga/icinga-go-library/backoff"
 	"github.com/icinga/icinga-go-library/com"
 	"github.com/icinga/icinga-go-library/database"
@@ -26,6 +28,7 @@ import (
 	"github.com/icinga/icinga-go-library/types"
 	"github.com/icinga/icinga-go-library/utils"
 	"github.com/icinga/icingadb/internal"
+	"github.com/icinga/icingadb/internal/config"
 	"github.com/icinga/icingadb/pkg/common"
 	"github.com/icinga/icingadb/pkg/contracts"
 	"github.com/icinga/icingadb/pkg/icingadb"
@@ -34,9 +37,18 @@ import (
 	v1history "github.com/icinga/icingadb/pkg/icingadb/v1/history"
 	"github.com/icinga/icingadb/pkg/icingaredis"
 	"github.com/icinga/icingadb/pkg/icingaredis/telemetry"
+	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"golang.org/x/sync/errgroup"
+)
+
+var (
+	// errClientReset is used as a cancellation cause when replacing or removing the Notifications client.
+	errClientReset = errors.New("notifications client was reset")
+
+	// errNonVolatileNonHardState is returned when a non-hard state change is attempted to be submitted for a non-volatile checkable.
+	errNonVolatileNonHardState = errors.New("non-hard state change for non-volatile checkable")
 )
 
 // fetchableEvent wraps both event.Event and relations, allowing to enrich the Event based on Notifications feedback.
@@ -64,51 +76,453 @@ func (ev *fetchableEvent) completeAndUpdate(ctx context.Context, attributes []st
 	return nil
 }
 
+// apiClientSession holds the Icinga Notifications API client, its runtime config and the associated ctx and canceler.
+//
+// The ctx is canceled whenever an atomic swap of the current apiClientSession occurs, e.g., when the client is
+// reconfigured or unconfigured. This allows any ongoing operations to be aborted and cleaned up. The canceler
+// must always be called to release the associated resources.
+type apiClientSession struct {
+	// cfg is the (?runtime) config this session was created with.
+	// Always populated, even if the client is unconfigured (client == nil).
+	cfg config.NotificationsConfig
+
+	client *source.Client          // The Icinga Notifications API client. Nil if it is unconfigured (cfg.Url == "").
+	ctx    context.Context         // The associated ctx of the client. (client != nil) => (ctx != nil)
+	cancel context.CancelCauseFunc // The canceler for the associated ctx. (ctx != nil) => (cancel != nil)
+}
+
 // Client is an Icinga Notifications compatible client implementation to push events to Icinga Notifications.
 //
 // A new Client should be created by the NewNotificationsClient function. New history entries can be submitted by
 // calling the Client.Submit method.
 type Client struct {
-	source.Config
+	db          *database.DB
+	redisClient *redis.Client
+	logger      *logging.Logger
 
-	db     *database.DB
-	logger *logging.Logger
+	// initialConfig is the static YAML and/or env configuration. Used in Client.SynchronizeConfigWithDatabase.
+	initialConfig config.NotificationsConfig
 
-	notificationsClient *source.Client // The Icinga Notifications client used to interact with the API.
-	redisClient         *redis.Client  // redisClient is the Redis client used to fetch host and service names for events.
+	// currentAPIClient holds the current Icinga Notifications API client session.
+	//
+	// The client might get configured and unconfigured multiple times, so this pointer is used to atomically swap
+	// the client and its configuration whenever it is re-configured. The context of the previous client (if any)
+	// is canceled to abort any ongoing ops. If the client is unconfigured, the pointer holds a nil client.
+	currentAPIClient atomic.Pointer[apiClientSession]
+
+	// reconfiguredCh delivers a signal whenever the Icinga Notifications API client is reconfigured.
+	//
+	// The client might get configured and unconfigured multiple times, so this channel delivers an event each
+	// time the client is re-configured to inform the main sync loop to restart its work, so the config delta
+	// can be re-applied. If DB synchronization is disabled, this will block waiters forever and never deliver
+	// a signal (won't even be initialized).
+	reconfiguredCh chan struct{}
+
+	// persistedLockedConfigCh is closed by Client.PersistLockedConfigOnce after it has finished.
+	persistedLockedConfigCh chan struct{}
+	// persistLockedConfigOnce ensures Client.PersistLockedConfigOnce performs its work only once.
+	persistLockedConfigOnce sync.Once
+
+	// syncMu synchronizes Client.PersistLockedConfigOnce and Client.SynchronizeConfigWithDatabase and protects
+	// lastEndpointId. The latter is called again for each HA takeover, which may overlap with an invocation from
+	// a previous takeover which has not returned yet.
+	syncMu sync.Mutex
+	// lastEndpointId is the last known endpoint ID, fetched via Client.endpointId.
+	lastEndpointId types.Binary
 
 	// incidentsByObjId is a map of object IDs to incidents populated by the first call to ApplyDelta.
 	incidentsByObjId map[string]source.Incident
 	incidentsMu      sync.Mutex
 
-	// heartbeatOutCh is a channel used to send heartbeat signals to the HA controller.
-	heartbeatOutCh chan<- bool
+	ha *icingadb.HA
 }
 
 // NewNotificationsClient creates a new Client connected to an existing database and logger.
+//
+// If cfg.SynchronizeWithDatabase is false, the Client can be directly used. Otherwise, one initial
+// Client.PersistLockedConfigOnce call and a continuous Client.SynchronizeConfigWithDatabase call for each HA
+// activation is necessary.
 func NewNotificationsClient(
 	db *database.DB,
 	rc *redis.Client,
 	logger *logging.Logger,
-	cfg source.Config,
-	heartbeatOutCh chan<- bool,
+	cfg config.NotificationsConfig,
+	ha *icingadb.HA,
 ) (*Client, error) {
-	notificationsClient, err := source.NewClient(cfg, "Icinga DB "+internal.Version.Version)
-	if err != nil {
-		return nil, err
+	client := &Client{
+		db:          db,
+		redisClient: rc,
+		logger:      logger,
+
+		initialConfig: cfg,
+
+		persistedLockedConfigCh: make(chan struct{}),
+
+		ha: ha,
+	}
+	// Init the atomic value with a valid pointer to simplify its swap and load operations.
+	client.currentAPIClient.Store(&apiClientSession{})
+
+	if !cfg.SynchronizeWithDatabase {
+		if _, err := client.exchangeAPIClientSession(cfg, true); err != nil {
+			return nil, err
+		}
+	} else {
+		client.reconfiguredCh = make(chan struct{})
 	}
 
-	return &Client{
-		Config: cfg,
+	return client, nil
+}
 
-		db:     db,
-		logger: logger,
+// exchangeAPIClientSession exchanges the current Icinga Notifications API client session with a new one.
+//
+// This method atomically swaps the current apiClientSession with a newly created one. If 'withClient' is
+// true, a new Icinga Notifications API client is created and associated with the new session. The context
+// of the previous client (if any) is canceled to abort any ongoing operations. Also, a signal is sent to the
+// reconfiguredCh channel to inform the sync loop to restart its work, but may be dropped if no one is listening.
+//
+// Returns the previous apiClientSession and any error encountered while creating the new client.
+func (client *Client) exchangeAPIClientSession(cfg config.NotificationsConfig, withClient bool) (*apiClientSession, error) {
+	newSession := &apiClientSession{cfg: cfg}
+	if withClient {
+		nc, err := source.NewClient(cfg.Config, "Icinga DB "+internal.Version.Version)
+		if err != nil {
+			return nil, err
+		}
+		newSession.client = nc
+		newSession.ctx, newSession.cancel = context.WithCancelCause(context.Background())
+	}
 
-		notificationsClient: notificationsClient,
-		redisClient:         rc,
+	prev := client.currentAPIClient.Swap(newSession)
+	if prev.cancel != nil {
+		prev.cancel(errClientReset)
+	}
 
-		heartbeatOutCh: heartbeatOutCh,
-	}, nil
+	if client.reconfiguredCh != nil && withClient {
+		// We don't know how long the client was in an unconfigured state, so we need to signal the
+		// main sync loop to restart its work again, so that the config delta can be re-applied.
+		select {
+		case client.reconfiguredCh <- struct{}{}:
+		default:
+			// Main sync loop is not listening, probably due to an ongoing HA handover/takeover?
+			// Doesn't matter, drop the signal.
+		}
+	}
+
+	return prev, nil
+}
+
+// apiClient returns the current Icinga Notifications API client along with a derived context.
+//
+// The returned context is canceled whenever the current apiClientSession is replaced, e.g., when it is reconfigured
+// or unconfigured, the provided ctx is canceled, or when the returned canceler is called, whichever happens first.
+// If a non-nil session is returned, the canceler must always be called to release the associated resources.
+//
+// If the client is unconfigured, nil values are returned for all three return values.
+func (client *Client) apiClient(ctx context.Context) (*source.Client, context.Context, context.CancelFunc) {
+	current := client.currentAPIClient.Load()
+	if current.client == nil {
+		return nil, nil, nil
+	}
+
+	ctx, cancel := context.WithCancelCause(ctx)
+	stopAfterFunc := context.AfterFunc(current.ctx, func() { cancel(context.Cause(current.ctx)) })
+
+	return current.client, ctx, func() { stopAfterFunc(); cancel(nil) }
+}
+
+// ReconfiguredCh returns a channel that delivers a signal whenever the Icinga Notifications API client is reconfigured.
+//
+// If DB synchronization is disabled, a nil channel is returned and waiters will block forever.
+func (client *Client) ReconfiguredCh() <-chan struct{} { return client.reconfiguredCh }
+
+// IsConfigured reports whether the Icinga Notifications API client is available.
+func (client *Client) IsConfigured() bool { return client.currentAPIClient.Load().client != nil }
+
+// endpointId returns this node's endpoint ID or the null endpoint ID, if unconfigured.
+func (client *Client) endpointId() types.Binary {
+	endpointId := client.ha.EndpointID()
+	if endpointId.Valid() {
+		return endpointId
+	}
+
+	return v1.UnconfiguredEndpointId()
+}
+
+// PersistLockedConfigOnce writes the static Notifications configuration to the database.
+//
+// This method must only be called once, as the static configuration is not expected to change; subsequent calls
+// return an error without performing any work. If the Client config disabled SynchronizeConfigWithDatabase, the
+// method immediately returns with a nil error.
+func (client *Client) PersistLockedConfigOnce(ctx context.Context) error {
+	if !client.initialConfig.SynchronizeWithDatabase {
+		return nil
+	}
+
+	err := errors.New("initial synchronization was already performed")
+	client.persistLockedConfigOnce.Do(func() {
+		if err = client.persistLockedConfig(ctx); err == nil {
+			close(client.persistedLockedConfigCh)
+		}
+	})
+
+	return err
+}
+
+// persistLockedConfig performs PersistLockedConfigOnce's database interaction, retrying until it succeeds.
+func (client *Client) persistLockedConfig(ctx context.Context) error {
+	client.syncMu.Lock()
+	defer client.syncMu.Unlock()
+
+	// errNotYetPopulated is returned in retry.WithBackoff below if environmentId is unset. Might happen if HA is raced.
+	errNotYetPopulated := errors.New("notifications client is not yet populated")
+
+	cleanupOrphansStmt := client.db.Rebind(
+		`DELETE FROM "icingadb_config"
+		 WHERE
+			 "environment_id" = ? AND
+			 "endpoint_id" <> ? AND
+			 NOT EXISTS (
+				 SELECT 1 FROM "icingadb_instance"
+				 WHERE
+					 "icingadb_instance"."environment_id" = "icingadb_config"."environment_id" AND
+					 "icingadb_instance"."endpoint_id" = "icingadb_config"."endpoint_id")`)
+	cleanupSelfStmt := client.db.Rebind(
+		`DELETE FROM "icingadb_config"
+		 WHERE "environment_id" = ? AND "endpoint_id" = ? AND "locked" = 'y'`)
+	upsertStmt, _ := client.db.BuildUpsertStmt(&v1.IcingadbConfig{})
+
+	retrySettings := client.db.GetDefaultRetrySettings()
+	retrySettings.Timeout = 0
+	innerOnRetryableError, innerOnSuccess := retrySettings.OnRetryableError, retrySettings.OnSuccess
+	retrySettings.OnRetryableError = func(elapsed time.Duration, attempt uint64, err, lastErr error) {
+		if errors.Is(err, errNotYetPopulated) {
+			return
+		}
+		innerOnRetryableError(elapsed, attempt, err, lastErr)
+	}
+	retrySettings.OnSuccess = func(elapsed time.Duration, attempt uint64, lastErr error) {
+		if errors.Is(lastErr, errNotYetPopulated) {
+			return
+		}
+		innerOnSuccess(elapsed, attempt, lastErr)
+	}
+
+	err := retry.WithBackoff(
+		ctx,
+		func(ctx context.Context) error {
+			if client.ha.Environment() == nil {
+				return errNotYetPopulated
+			}
+
+			environmentId := client.ha.Environment().Meta().EnvironmentId
+			client.lastEndpointId = client.endpointId()
+
+			if !environmentId.Valid() {
+				return errNotYetPopulated
+			}
+
+			return client.db.ExecTx(ctx, nil, func(ctx context.Context, tx *sqlx.Tx) error {
+				_, err := tx.ExecContext(ctx, cleanupOrphansStmt, environmentId, v1.UnconfiguredEndpointId())
+				if err != nil {
+					return database.CantPerformQuery(err, cleanupOrphansStmt)
+				}
+
+				_, err = tx.ExecContext(ctx, cleanupSelfStmt, environmentId, client.lastEndpointId)
+				if err != nil {
+					return database.CantPerformQuery(err, cleanupSelfStmt)
+				}
+
+				for k, v := range client.initialConfig.StaticConfig() {
+					_, err = tx.NamedExecContext(
+						ctx,
+						upsertStmt,
+						&v1.IcingadbConfig{
+							EnvironmentMeta: v1.EnvironmentMeta{EnvironmentId: environmentId},
+							EnvKey:          k,
+							EnvValue:        v,
+							EndpointId:      client.lastEndpointId,
+							Locked:          types.MakeBool(true),
+						})
+					if err != nil {
+						return database.CantPerformQuery(err, upsertStmt)
+					}
+				}
+
+				return nil
+			})
+		},
+		func(err error) bool {
+			if errors.Is(err, errNotYetPopulated) {
+				return true
+			}
+			return retry.Retryable(err)
+		},
+		backoff.DefaultBackoff,
+		retrySettings)
+
+	return errors.Wrap(err, "cannot synchronize locked config")
+}
+
+// SynchronizeConfigWithDatabase checks the database-stored configuration periodically and applies changes.
+//
+// This method blocks until the provided context is done. Runtime errors are only reported via the logging. If the
+// Client config disabled SynchronizeConfigWithDatabase, the method immediately returns with a nil error.
+//
+// At the moment, not all possible env_keys are being consumed, but only those listed on an internal allow list.
+func (client *Client) SynchronizeConfigWithDatabase(ctx context.Context) error {
+	if !client.initialConfig.SynchronizeWithDatabase {
+		return nil
+	}
+
+	client.logger.Info("Starting Icinga Notifications configuration sync")
+
+	// envKeys is an allow list for env_keys we are consuming. At the moment, not all keys are used by web and
+	// some might cause issues. Then, all locked keys are being removed from the list.
+	// Context: https://github.com/Icinga/icingadb/pull/1158#discussion_r3758216321
+	envKeys := []string{
+		"ICINGADB_NOTIFICATIONS_URL",
+		"ICINGADB_NOTIFICATIONS_DEFAULT_RELATIONS",
+		"ICINGADB_NOTIFICATIONS_ICINGAWEB2_URL",
+	}
+
+	lockedKeys := client.initialConfig.StaticConfig()
+	envKeys = slices.DeleteFunc(envKeys, func(k string) bool {
+		_, locked := lockedKeys[k]
+		return locked
+	})
+
+	// envKeyArgs are the trailing selectStmt query arguments; its leading ones are added in performSync below.
+	envKeyArgs := make([]any, len(envKeys))
+	for i, envKey := range envKeys {
+		envKeyArgs[i] = envKey
+	}
+
+	// selectStmt is used to fetch unlocked config for this node.
+	// Note: The query is invalid if there are no env_keys, but then it will not be executed.
+	selectStmt := client.db.Rebind(client.db.BuildSelectStmt(&v1.IcingadbConfig{}, &v1.IcingadbConfig{}) +
+		` WHERE "environment_id" = ? AND "endpoint_id" = ? AND "locked" = 'n'` +
+		` AND "env_key" IN (` + strings.Join(slices.Repeat([]string{"?"}, len(envKeys)), ", ") + `)`)
+
+	// updateStmt is used when the endpoint ID has changed; affecting all rows, regardless of their "locked" state.
+	updateStmt := client.db.Rebind(`
+		UPDATE "icingadb_config"
+		SET "endpoint_id" = ?
+		WHERE "environment_id" = ? AND "endpoint_id" = ?`)
+
+	performSync := func() {
+		client.syncMu.Lock()
+		defer client.syncMu.Unlock()
+
+		haEnvironment := client.ha.Environment()
+		if haEnvironment == nil {
+			client.logger.Warn("Cannot find active HA Environment")
+			return
+		}
+
+		environmentId := haEnvironment.Meta().EnvironmentId
+		if !environmentId.Valid() {
+			client.logger.Warn("Environment ID from HA is unpopulated")
+			return
+		}
+
+		if newEndpointId := client.endpointId(); !slices.Equal(client.lastEndpointId, newEndpointId) {
+			client.logger.Infow("Endpoint ID has changed, updating configuration",
+				zap.Stringer("old_endpoint_id", client.lastEndpointId),
+				zap.Stringer("new_endpoint_id", newEndpointId))
+
+			_, err := client.db.ExecContext(ctx, updateStmt, newEndpointId, environmentId, client.lastEndpointId)
+			if err != nil {
+				client.logger.Errorw("Cannot update icingadb_config after endpoint ID change",
+					zap.Error(database.CantPerformQuery(err, updateStmt)))
+			} else {
+				client.lastEndpointId = newEndpointId
+			}
+		}
+
+		// If there are no env_keys, but the client is not configured, we might (!) have already enough locked
+		// config to get it working. So, give it a try. Note: The SELECT query is excluded below.
+		//
+		// Otherwise, there is nothing to do here anymore except waiting for the context to be done.
+		if len(envKeys) == 0 && client.IsConfigured() {
+			return
+		}
+
+		newConf := client.initialConfig
+
+		if len(envKeys) > 0 {
+			var dbConfRows []v1.IcingadbConfig
+			err := client.db.SelectContext(
+				ctx,
+				&dbConfRows,
+				selectStmt,
+				append([]any{environmentId, client.lastEndpointId}, envKeyArgs...)...)
+			if err != nil {
+				client.logger.Errorw("Cannot fetch configuration from database", zap.Error(err))
+				return
+			}
+
+			envConf := make(map[string]string, len(dbConfRows))
+			for _, row := range dbConfRows {
+				envConf[row.EnvKey] = row.EnvValue
+			}
+
+			err = env.ParseWithOptions(&newConf, env.Options{Prefix: "ICINGADB_NOTIFICATIONS_", Environment: envConf})
+			if err != nil {
+				client.logger.Errorw("New Icinga Notifications configuration from the database cannot be parsed", zap.Error(err))
+				return
+			}
+
+			// After initial parsing, a config with a password_file also contains a password. Later, a re-verification
+			// will fail as both fields are set. So, just unset the password_file at this point.
+			newConf.PasswordFile = ""
+
+			err = newConf.Validate()
+			if err != nil {
+				client.logger.Errorw("New Icinga Notifications configuration from the database is invalid", zap.Error(err))
+				return
+			}
+		}
+
+		if reflect.DeepEqual(newConf, client.currentAPIClient.Load().cfg) {
+			return
+		}
+
+		prev, err := client.exchangeAPIClientSession(newConf, newConf.Url != "")
+		if err != nil {
+			client.logger.Errorw("Cannot create new Notifications client from database configuration", zap.Error(err))
+			return
+		}
+
+		switch {
+		case newConf.Url != "":
+			client.logger.Info("Synchronized new Icinga Notifications configuration from the database")
+		case prev.client != nil:
+			client.sendHeartbeatBlocking(ctx, types.Bool{})
+			client.logger.Info("Stopped Icinga Notifications client as no URL is configured anymore")
+		default:
+			client.logger.Debug("Postponing Notifications config synchronization step as no URL is configured")
+		}
+	}
+
+	select {
+	case <-client.persistedLockedConfigCh:
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+
+	performSync()
+
+	ticker := time.NewTicker(15 * time.Second)
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+
+		case <-ticker.C:
+			performSync()
+		}
+	}
 }
 
 // ClearIncidents clears the cached incidents previously populated by the [Client.ApplyDelta].
@@ -144,6 +558,13 @@ func (client *Client) ApplyDelta(ctx context.Context, delta *icingadb.Delta) err
 		return nil
 	}
 
+	nc, ctx, cancel := client.apiClient(ctx)
+	if nc == nil {
+		client.logger.Debug("Cannot apply delta as the Notifications Client is not yet configured")
+		return nil
+	}
+	defer cancel()
+
 	func() {
 		client.incidentsMu.Lock()
 		defer client.incidentsMu.Unlock()
@@ -153,7 +574,7 @@ func (client *Client) ApplyDelta(ctx context.Context, delta *icingadb.Delta) err
 		if client.incidentsByObjId != nil {
 			return
 		}
-		client.incidentsByObjId = client.retrieveEnvironmentIncidents(ctx)
+		client.incidentsByObjId = client.retrieveEnvironmentIncidents(ctx, nc)
 	}()
 	if len(client.incidentsByObjId) == 0 {
 		return nil
@@ -233,7 +654,7 @@ func (client *Client) ApplyDelta(ctx context.Context, delta *icingadb.Delta) err
 			delta.Subject.Name())
 
 		attrs := source.ModifiableIncidentAttrs{Close: types.MakeBool(true)}
-		if err := client.notificationsClient.ModifyIncidents(ctx, attrs, filter); err != nil {
+		if err := nc.ModifyIncidents(ctx, attrs, filter); err != nil {
 			client.logger.Errorw("Failed to bulk close obsolete incidents for deleted objects",
 				zap.String("entity", delta.Subject.Name()),
 				zap.Int("count", len(filter)),
@@ -242,7 +663,13 @@ func (client *Client) ApplyDelta(ctx context.Context, delta *icingadb.Delta) err
 		return nil
 	})
 
-	return g.Wait()
+	err := g.Wait()
+	if errors.Is(context.Cause(ctx), errClientReset) {
+		client.logger.Debug("Stopped applying delta as the Icinga Notifications client was replaced")
+		return nil
+	}
+
+	return err
 }
 
 // SyncCheckOutputs periodically syncs the check outputs of all hosts and services to the Icinga Notifications API.
@@ -254,7 +681,7 @@ func (client *Client) SyncCheckOutputs(ctx context.Context) error {
 	lastSync := time.Now()
 
 	// modify is a helper function to update the check output of a given state in Icinga Notifications.
-	modify := func(s *v1.State, idTags map[string]string) error {
+	modify := func(ctx context.Context, nc *source.Client, s *v1.State, idTags map[string]string) error {
 		if !s.Output.Valid || s.LastUpdate.Time().Before(lastSync) {
 			return nil // Skip state updates that haven't changed since the last sync, or that don't have a valid output.
 		}
@@ -279,12 +706,12 @@ func (client *Client) SyncCheckOutputs(ctx context.Context) error {
 		attrs := source.ModifiableIncidentAttrs{Message: types.MakeString(sb.String())}
 		return retry.WithBackoff(
 			ctx,
-			func(ctx context.Context) error { return client.notificationsClient.ModifyIncidents(ctx, attrs, filter) },
+			func(ctx context.Context) error { return nc.ModifyIncidents(ctx, attrs, filter) },
 			func(err error) bool { return true },
 			backoff.DefaultBackoff,
 			retry.Settings{
 				OnSuccess: func(elapsed time.Duration, attempt uint64, err error) {
-					client.sendHeartbeat(true)
+					client.sendHeartbeat(types.MakeBool(true))
 					if attempt > 1 {
 						client.logger.Debugw("Successfully updated incident status after retries",
 							zap.String("object_type", types.Name(s)),
@@ -294,7 +721,7 @@ func (client *Client) SyncCheckOutputs(ctx context.Context) error {
 					}
 				},
 				OnRetryableError: func(elapsed time.Duration, attempt uint64, err, lastErr error) {
-					client.sendHeartbeat(false)
+					client.sendHeartbeat(types.MakeBool(false))
 					if lastErr == nil || err.Error() != lastErr.Error() {
 						client.logger.Errorw("Failed to update incident status",
 							zap.String("object_type", types.Name(s)),
@@ -316,9 +743,15 @@ func (client *Client) SyncCheckOutputs(ctx context.Context) error {
 			return ctx.Err()
 
 		case tick := <-ticker.C:
+			nc, ctx, cancel := client.apiClient(ctx)
+			if nc == nil {
+				client.logger.Debug("Cannot sync check outputs as the Notifications Client is not yet configured")
+				continue
+			}
+
 			hostIncidents := make(map[string]source.Incident)
 			serviceIncidents := make(map[string]source.Incident)
-			for id, incident := range client.retrieveEnvironmentIncidents(ctx) {
+			for id, incident := range client.retrieveEnvironmentIncidents(ctx, nc) {
 				if _, exists := incident.ObjectTags["service"]; exists {
 					serviceIncidents[id] = incident
 				} else {
@@ -335,7 +768,7 @@ func (client *Client) SyncCheckOutputs(ctx context.Context) error {
 			if len(hostIncidents) > 0 {
 				wg.Go(func() {
 					_ = streamRedisHashObjects(ctx, client.redisClient, "icinga:host:state", func(hs *v1.HostState, _ string) error {
-						return modify(&hs.State, hostIncidents[hs.HostId.String()].ObjectTags)
+						return modify(ctx, nc, &hs.State, hostIncidents[hs.HostId.String()].ObjectTags)
 					}, slices.Collect(maps.Keys(hostIncidents))...)
 				})
 			}
@@ -343,11 +776,12 @@ func (client *Client) SyncCheckOutputs(ctx context.Context) error {
 			if len(serviceIncidents) > 0 {
 				wg.Go(func() {
 					_ = streamRedisHashObjects(ctx, client.redisClient, "icinga:service:state", func(ss *v1.ServiceState, _ string) error {
-						return modify(&ss.State, serviceIncidents[ss.ServiceId.String()].ObjectTags)
+						return modify(ctx, nc, &ss.State, serviceIncidents[ss.ServiceId.String()].ObjectTags)
 					}, slices.Collect(maps.Keys(serviceIncidents))...)
 				})
 			}
 			wg.Wait()
+			cancel()
 
 			lastSync = tick
 			// In case the sync took a long time, the next tick might come immediately,
@@ -362,13 +796,14 @@ func (client *Client) SyncCheckOutputs(ctx context.Context) error {
 // The incidents are returned as a map of object IDs to incidents. The object IDs are generated based on the
 // environment ID and the host/service names, mimicking the Icinga 2 ID generation behavior used to generate
 // all Icinga DB related object IDs.
-func (client *Client) retrieveEnvironmentIncidents(ctx context.Context) map[string]source.Incident {
+func (client *Client) retrieveEnvironmentIncidents(ctx context.Context, nc *source.Client) map[string]source.Incident {
 	environment, ok := v1.EnvironmentFromContext(ctx)
 	if !ok {
 		panic("cannot get environment from context")
 	}
 
-	incidentsCh, errCh := client.notificationsClient.YieldIncidents(ctx, map[string]string{"environment": environment.ID().String()})
+	incidentsCh, errCh := nc.YieldIncidents(
+		ctx, map[string]string{"environment": environment.ID().String()})
 
 	incidentsByID := make(map[string]source.Incident)
 	hash := sha1.New() // #nosec G401 -- used as a non-cryptographic hash function to hash IDs
@@ -393,19 +828,37 @@ func (client *Client) retrieveEnvironmentIncidents(ctx context.Context) map[stri
 		hash.Reset()
 	}
 
-	if err := <-errCh; err != nil {
-		client.sendHeartbeat(false)
+	if err := <-errCh; err != nil && ctx.Err() == nil {
+		client.sendHeartbeat(types.MakeBool(false))
 		client.logger.Errorw("Failed to fetch incidents", zap.String("error", err.Error()))
 	}
 	return incidentsByID
 }
 
-// sendHeartbeat sends a heartbeat signal to the HA controller via the heartbeatOutCh channel.
-func (client *Client) sendHeartbeat(alive bool) {
+// sendHeartbeat sends a heartbeat signal to the HA controller.
+//
+// The signal is dropped if this Client is unconfigured or if the HA controller is currently not listening.
+func (client *Client) sendHeartbeat(alive types.Bool) {
+	if !client.IsConfigured() {
+		return
+	}
+
 	select {
-	case client.heartbeatOutCh <- alive:
+	case client.ha.NotificationsHeartbeat() <- alive:
 	default:
-		client.logger.Debugw("Heartbeat channel is full, dropping signal", zap.Bool("healthy", alive))
+		client.logger.Debugw("Heartbeat channel is full, dropping signal", zap.Any("healthy", alive))
+	}
+}
+
+// sendHeartbeatBlocking sends a heartbeat signal to the HA controller, blocking until it was received or ctx is done.
+//
+// An invalid types.Bool resets the state to unknown, e.g., after this Client became unconfigured. As such signals are
+// only sent once, they must not be dropped like those of Client.sendHeartbeat.
+func (client *Client) sendHeartbeatBlocking(ctx context.Context, alive types.Bool) {
+	select {
+	case client.ha.NotificationsHeartbeat() <- alive:
+	case <-ctx.Done():
+		client.logger.Debugw("Cannot send heartbeat, context is done", zap.Any("healthy", alive))
 	}
 }
 
@@ -436,6 +889,11 @@ func (client *Client) buildCommonEvent(
 	}
 	objectName = rel.Host.DisplayName
 
+	current := client.currentAPIClient.Load()
+	if current.client == nil {
+		return nil, errors.New("unpopulated API client")
+	}
+
 	if serviceId != nil {
 		if len(rel.Services) == 0 {
 			return nil, errors.New("relations does not contain a service")
@@ -443,8 +901,8 @@ func (client *Client) buildCommonEvent(
 		serviceName := rel.Services[0].Name
 
 		objectName += ": " + rel.Services[0].DisplayName
-		if client.Icingaweb2UrlParsed != nil {
-			objectUrl = client.Icingaweb2UrlParsed.JoinPath("/icingadb/service").String()
+		if current.cfg.Icingaweb2UrlParsed != nil {
+			objectUrl = current.cfg.Icingaweb2UrlParsed.JoinPath("/icingadb/service").String()
 			objectUrl += "?name=" + utils.RawUrlEncode(serviceName) +
 				"&host.name=" + utils.RawUrlEncode(rel.Host.Name)
 		}
@@ -453,8 +911,8 @@ func (client *Client) buildCommonEvent(
 			"service": serviceName,
 		}
 	} else {
-		if client.Icingaweb2UrlParsed != nil {
-			objectUrl = client.Icingaweb2UrlParsed.JoinPath("/icingadb/host").String()
+		if current.cfg.Icingaweb2UrlParsed != nil {
+			objectUrl = current.cfg.Icingaweb2UrlParsed.JoinPath("/icingadb/host").String()
 			objectUrl += "?name=" + utils.RawUrlEncode(rel.Host.Name)
 		}
 		objectTags = map[string]string{
@@ -474,9 +932,6 @@ func (client *Client) buildCommonEvent(
 		relations: rel,
 	}, nil
 }
-
-// errNonVolatileNonHardState is returned when a non-hard state change is attempted to be submitted for a non-volatile checkable.
-var errNonVolatileNonHardState = errors.New("non-hard state change for non-volatile checkable")
 
 // buildStateEvent builds a fully initialized event.Event from a state history entry.
 //
@@ -644,6 +1099,12 @@ func (client *Client) buildAcknowledgementHistoryEvent(ctx context.Context, h *v
 // Note that this function is used as [icingadb.RUUpsertFunc] for the runtime updates pipeline, so its signature must
 // match the [icingadb.RUUpsertFunc] type.
 func (client *Client) Submit(ctx context.Context, entity database.Entity) error {
+	nc, ctx, cancel := client.apiClient(ctx)
+	if nc == nil {
+		return nil
+	}
+	defer cancel()
+
 	var (
 		ev       *fetchableEvent
 		eventErr error
@@ -708,8 +1169,9 @@ func (client *Client) Submit(ctx context.Context, entity database.Entity) error 
 		return nil
 	}
 
-	attributes := client.DefaultRelations
-	return retry.WithBackoff(
+	attributes := client.currentAPIClient.Load().cfg.DefaultRelations
+
+	err := retry.WithBackoff(
 		ctx,
 		func(ctx context.Context) (err error) {
 			for {
@@ -721,7 +1183,7 @@ func (client *Client) Submit(ctx context.Context, entity database.Entity) error 
 					return err
 				}
 
-				attributes, err = client.notificationsClient.ProcessEvent(ctx, ev.Event, true)
+				attributes, err = nc.ProcessEvent(ctx, ev.Event, true)
 				if errors.Is(err, source.ErrAttrsNegotiation) {
 					client.logger.Debugw("Icinga Notifications requested more attributes",
 						zap.String("event", ev.Name),
@@ -735,7 +1197,7 @@ func (client *Client) Submit(ctx context.Context, entity database.Entity) error 
 		backoff.DefaultBackoff,
 		retry.Settings{
 			OnSuccess: func(elapsed time.Duration, attempt uint64, lastErr error) {
-				client.sendHeartbeat(true)
+				client.sendHeartbeat(types.MakeBool(true))
 				telemetry.Stats.NotificationSync.Add(1)
 
 				client.logger.Debugw("Successfully submitted event to Icinga Notifications",
@@ -745,7 +1207,7 @@ func (client *Client) Submit(ctx context.Context, entity database.Entity) error 
 					zap.Error(lastErr))
 			},
 			OnRetryableError: func(elapsed time.Duration, attempt uint64, err, lastErr error) {
-				client.sendHeartbeat(false)
+				client.sendHeartbeat(types.MakeBool(false))
 
 				if lastErr == nil || err.Error() != lastErr.Error() {
 					client.logger.Errorw("Cannot submit event to Icinga Notifications",
@@ -757,6 +1219,13 @@ func (client *Client) Submit(ctx context.Context, entity database.Entity) error 
 			},
 		},
 	)
+	if errors.Is(context.Cause(ctx), errClientReset) {
+		client.logger.Debugw("Stopped submitting event as the Icinga Notifications client was replaced",
+			zap.String("event", ev.Name))
+		return nil
+	}
+
+	return err
 }
 
 // SyncExtraStages returns a map of history sync keys to [history.StageFunc] to be used for [history.Sync].

--- a/schema/mysql/schema.sql
+++ b/schema/mysql/schema.sql
@@ -553,6 +553,7 @@ CREATE TABLE icingadb_instance (
   icingadb_service_user varchar(255) NOT NULL, -- see https://systemd.io/USER_NAMES/ for the restrictions on usernames.
   notifications_healthy enum('n', 'y') DEFAULT NULL, -- NULL means unknown, n means unhealthy, y means healthy.
   notifications_discovered_socket_path mediumtext, -- The discovered Icinga Notifications socket path, if any.
+  notifications_synchronize_with_database enum('n', 'y') NOT NULL,
 
   PRIMARY KEY (id)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
@@ -1406,6 +1407,18 @@ CREATE TABLE dependency_edge (
   CONSTRAINT pk_dependency_edge PRIMARY KEY (id),
 
   UNIQUE INDEX idx_dependency_edge_from_node_to_node_id (from_node_id, to_node_id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
+
+CREATE TABLE icingadb_config (
+  environment_id binary(20) NOT NULL COMMENT 'environment.id',
+  endpoint_id binary(20) NOT NULL DEFAULT 0x0000000000000000000000000000000000000000 COMMENT 'endpoint.id, all zero bytes if unknown',
+
+  env_key varchar(255) NOT NULL,
+  env_value text NOT NULL,
+
+  locked enum('n', 'y') NOT NULL COMMENT 'static config from Icinga DB config is considered as locked',
+
+  CONSTRAINT pk_icingadb_config PRIMARY KEY (environment_id, endpoint_id, env_key)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;
 
 CREATE TABLE icingadb_schema (

--- a/schema/mysql/upgrades/add-icingadb_config.sql
+++ b/schema/mysql/upgrades/add-icingadb_config.sql
@@ -1,0 +1,13 @@
+ALTER TABLE icingadb_instance ADD COLUMN notifications_synchronize_with_database enum('n', 'y') NOT NULL;
+
+CREATE TABLE icingadb_config (
+  environment_id binary(20) NOT NULL COMMENT 'environment.id',
+  endpoint_id binary(20) NOT NULL DEFAULT 0x0000000000000000000000000000000000000000 COMMENT 'endpoint.id, all zero bytes if unknown',
+
+  env_key varchar(255) NOT NULL,
+  env_value text NOT NULL,
+
+  locked enum('n', 'y') NOT NULL COMMENT 'static config from Icinga DB config is considered as locked',
+
+  CONSTRAINT pk_icingadb_config PRIMARY KEY (environment_id, endpoint_id, env_key)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_bin ROW_FORMAT=DYNAMIC;

--- a/schema/pgsql/schema.sql
+++ b/schema/pgsql/schema.sql
@@ -804,6 +804,7 @@ CREATE TABLE icingadb_instance (
   icingadb_service_user varchar(255) NOT NULL, -- see https://systemd.io/USER_NAMES/ for the restrictions on usernames.
   notifications_healthy boolenum DEFAULT NULL, -- NULL means unknown, n means unhealthy, y means healthy.
   notifications_discovered_socket_path text, -- The discovered Icinga Notifications socket path, if any.
+  notifications_synchronize_with_database boolenum NOT NULL DEFAULT 'n',
 
   CONSTRAINT pk_icingadb_instance PRIMARY KEY (id)
 );
@@ -2288,6 +2289,25 @@ COMMENT ON COLUMN dependency_edge.environment_id IS 'environment.id';
 COMMENT ON COLUMN dependency_edge.from_node_id IS 'dependency_node.id';
 COMMENT ON COLUMN dependency_edge.to_node_id IS 'dependency_node.id';
 COMMENT ON COLUMN dependency_edge.dependency_edge_state_id IS 'sha1(dependency_edge_state.id)';
+
+CREATE TABLE icingadb_config (
+  environment_id bytea20 NOT NULL,
+  endpoint_id bytea20 NOT NULL DEFAULT '\x0000000000000000000000000000000000000000',
+
+  env_key varchar(255) NOT NULL,
+  env_value text NOT NULL,
+
+  locked boolenum NOT NULL DEFAULT 'n',
+
+  CONSTRAINT pk_icingadb_config PRIMARY KEY (environment_id, endpoint_id, env_key)
+);
+
+ALTER TABLE icingadb_config ALTER COLUMN environment_id SET STORAGE PLAIN;
+ALTER TABLE icingadb_config ALTER COLUMN endpoint_id SET STORAGE PLAIN;
+
+COMMENT ON COLUMN icingadb_config.environment_id IS 'environment.id';
+COMMENT ON COLUMN icingadb_config.endpoint_id IS 'endpoint.id, all zero bytes if unknown';
+COMMENT ON COLUMN icingadb_config.locked IS 'static config from Icinga DB config is considered as locked';
 
 CREATE SEQUENCE icingadb_schema_id_seq;
 

--- a/schema/pgsql/upgrades/add-icingadb_config.sql
+++ b/schema/pgsql/upgrades/add-icingadb_config.sql
@@ -1,0 +1,20 @@
+ALTER TABLE icingadb_instance ADD COLUMN notifications_synchronize_with_database boolenum NOT NULL DEFAULT 'n';
+
+CREATE TABLE icingadb_config (
+  environment_id bytea20 NOT NULL,
+  endpoint_id bytea20 NOT NULL DEFAULT '\x0000000000000000000000000000000000000000',
+
+  env_key varchar(255) NOT NULL,
+  env_value text NOT NULL,
+
+  locked boolenum NOT NULL DEFAULT 'n',
+
+  CONSTRAINT pk_icingadb_config PRIMARY KEY (environment_id, endpoint_id, env_key)
+);
+
+ALTER TABLE icingadb_config ALTER COLUMN environment_id SET STORAGE PLAIN;
+ALTER TABLE icingadb_config ALTER COLUMN endpoint_id SET STORAGE PLAIN;
+
+COMMENT ON COLUMN icingadb_config.environment_id IS 'environment.id';
+COMMENT ON COLUMN icingadb_config.endpoint_id IS 'endpoint.id, all zero bytes if unknown';
+COMMENT ON COLUMN icingadb_config.locked IS 'static config from Icinga DB config is considered as locked';


### PR DESCRIPTION
A new configuration path for the Icinga Notifications client based on the database was added. While manually configured fields from Icinga DB take precedence, allowed fields from the database can be used. By request, this feature is opt-out and can be disabled.

---

The docs state that "a MySQL (≥8.0), MariaDB (≥10.2.2), or PostgreSQL (≥9.6) database is required to run Icinga DB." So, let's get rid of the outdated ones.

---

I have removed the unsupported versions as they are, well, unsupported and that the new index has a size of 20 + 255*4 + 20 = 1060, which exceeds MariaDB's old limit.

Fixes #1108.