### PR TITLE
notifications: transmit event object names differently

### DIFF
--- a/pkg/notifications/notifications.go
+++ b/pkg/notifications/notifications.go
@@ -426,10 +426,7 @@ func (client *Client) buildCommonEvent(
 	}
 
 	var (
-		objectName  string
-		hostName    string
-		serviceName string
-
+		objectName string
 		objectUrl  string
 		objectTags map[string]string
 	)
@@ -437,26 +434,25 @@ func (client *Client) buildCommonEvent(
 	if rel.Host == nil {
 		return nil, errors.New("relations does not contain a host")
 	}
-	hostName = rel.Host.Name
+	objectName = rel.Host.DisplayName
 
 	if serviceId != nil {
 		if len(rel.Services) == 0 {
 			return nil, errors.New("relations does not contain a service")
 		}
-		serviceName = rel.Services[0].Name
+		serviceName := rel.Services[0].Name
 
-		objectName = hostName + "!" + serviceName
+		objectName += ": " + rel.Services[0].DisplayName
 		objectUrl = "/icingadb/service?name=" + utils.RawUrlEncode(serviceName) +
-			"&host.name=" + utils.RawUrlEncode(hostName)
+			"&host.name=" + utils.RawUrlEncode(rel.Host.Name)
 		objectTags = map[string]string{
-			"host":    hostName,
+			"host":    rel.Host.Name,
 			"service": serviceName,
 		}
 	} else {
-		objectName = hostName
-		objectUrl = "/icingadb/host?name=" + utils.RawUrlEncode(hostName)
+		objectUrl = "/icingadb/host?name=" + utils.RawUrlEncode(rel.Host.Name)
 		objectTags = map[string]string{
-			"host": hostName,
+			"host": rel.Host.Name,
 		}
 	}
 


### PR DESCRIPTION
This PR transmits the event object names in a `<host.display_name>` and `host.display_name: service.display_name` format as requested in #1126.

<img width="1200" height="504" alt="Bildschirmfoto 2026-08-12 um 09 05 30" src="https://github.com/user-attachments/assets/5fb17791-489d-4a33-9725-475da1ae46f9" />

resolves #1126