### PR TITLE
notifications: log the latest error not the previous one

### DIFF
--- a/pkg/notifications/notifications.go
+++ b/pkg/notifications/notifications.go
@@ -299,7 +299,7 @@ func (client *Client) SyncCheckOutputs(ctx context.Context) error {
 						client.logger.Errorw("Failed to update incident status",
 							zap.String("object_type", types.Name(s)),
 							zap.Duration("elapsed", elapsed),
-							zap.Error(lastErr))
+							zap.Error(err))
 					}
 				},
 			},


### PR DESCRIPTION
This was an oversight from me. The `OnRetryableError` callback logs something only when the last and current error don't match but the log entry included always the previous error instead of the current one.